### PR TITLE
Add support for Teensy boards

### DIFF
--- a/Adafruit_SleepyDog.h
+++ b/Adafruit_SleepyDog.h
@@ -15,6 +15,10 @@
   // Teensy 3.x watchdog support.
   #include "utility/WatchdogKinetisK.h"
   typedef WatchdogKinetisKseries WatchdogType;
+#elif defined(__MKL26Z64__)
+  // Teensy LC watchdog support.
+  #include "utility/WatchdogKinetisL.h"
+  typedef WatchdogKinetisLseries WatchdogType;
 #else
   #error Unsupported platform for the Adafruit Watchdog library!
 #endif

--- a/Adafruit_SleepyDog.h
+++ b/Adafruit_SleepyDog.h
@@ -11,6 +11,10 @@
   // Arduino Zero / ATSAMD series CPU watchdog support.
   #include "utility/WatchdogSAMD.h"
   typedef WatchdogSAMD WatchdogType;
+#elif defined(__MK20DX128__) || defined(__MK20DX256__) || defined(__MK64FX512__) || defined(__MK66FX1M0__)
+  // Teensy 3.x watchdog support.
+  #include "utility/WatchdogKinetisK.h"
+  typedef WatchdogKinetisKseries WatchdogType;
 #else
   #error Unsupported platform for the Adafruit Watchdog library!
 #endif

--- a/examples/BasicUsage/BasicUsage.ino
+++ b/examples/BasicUsage/BasicUsage.ino
@@ -8,6 +8,7 @@
 
 void setup() {
   Serial.begin(115200);
+  while (!Serial) ; // wait for Arduino Serial Monitor (native USB boards)
   Serial.println("Adafruit Watchdog Library Demo!");
   Serial.println();
 

--- a/examples/Sleep/Sleep.ino
+++ b/examples/Sleep/Sleep.ino
@@ -8,6 +8,7 @@
 
 void setup() {
   Serial.begin(115200);
+  while (!Serial) ; // wait for Arduino Serial Monitor (native USB boards)
   Serial.println("Adafruit Watchdog Library Sleep Demo!");
   Serial.println();
 }

--- a/utility/WatchdogKinetisK.cpp
+++ b/utility/WatchdogKinetisK.cpp
@@ -1,0 +1,104 @@
+// Be careful to use a platform-specific conditional include to only make the
+// code visible for the appropriate platform.  Arduino will try to compile and
+// link all .cpp files regardless of platform.
+#if defined(__MK20DX128__) || defined(__MK20DX256__) || defined(__MK64FX512__) || defined(__MK66FX1M0__)
+
+#include <kinetis.h>
+#include "WatchdogKinetisK.h"
+
+static void one_bus_cycle(void) __attribute__((always_inline));
+static void watchdog_config(int cfg, int val);
+
+// Enable the watchdog timer to reset the machine after a period of time
+// without any calls to reset().  The passed in period (in milliseconds) is
+// just a suggestion and a lower value might be picked if the hardware does
+// not support the exact desired value.
+//
+// The actual period (in milliseconds) before a watchdog timer reset is
+// returned.
+int WatchdogKinetisKseries::enable(int maxPeriodMS)
+{
+	if (maxPeriodMS < 4) {
+		maxPeriodMS = 8000; // default is 8 seconds
+	}
+	if (setting != maxPeriodMS) {
+		watchdog_config(WDOG_STCTRLH_WDOGEN, maxPeriodMS);
+		setting = maxPeriodMS;
+	}
+	return maxPeriodMS;
+}
+
+// Reset or 'kick' the watchdog timer to prevent a reset of the device.
+void WatchdogKinetisKseries::reset()
+{
+	__disable_irq();
+	WDOG_REFRESH = 0xA602;
+	WDOG_REFRESH = 0xB480;
+	__enable_irq();
+}
+
+// Completely disable the watchdog timer.
+void WatchdogKinetisKseries::disable()
+{
+	if (setting > 0) {
+		watchdog_config(0, 4);
+		setting = 0;
+	}
+}
+
+// Enter the lowest power sleep mode for the desired period of time.  The
+// passed in period (in milliseconds) is just a suggestion and a lower value
+// might be picked if the hardware does not support the exact desired value
+//
+// The actual period (in milliseconds) that the hardware was asleep will be
+// returned.
+int WatchdogKinetisKseries::sleep(int maxPeriodMS)
+{
+	if (maxPeriodMS <= 0) return 0;
+	// TODO....
+	return 0;
+}
+
+static void watchdog_config(int cfg, int val)
+{
+	__disable_irq();
+	WDOG_UNLOCK = WDOG_UNLOCK_SEQ1;
+	WDOG_UNLOCK = WDOG_UNLOCK_SEQ2;
+	one_bus_cycle();
+	WDOG_STCTRLH = cfg | WDOG_STCTRLH_ALLOWUPDATE;
+	WDOG_TOVALH = val >> 16;
+	WDOG_TOVALL = val;
+	WDOG_PRESC = 0;
+	__enable_irq();
+	for (int i=0; i < 256; i++) {
+		one_bus_cycle();
+	}
+}
+
+static void one_bus_cycle(void)
+{
+	__asm__ volatile ("nop");
+	#if (F_CPU / F_BUS) > 1
+	__asm__ volatile ("nop");
+	#endif
+	#if (F_CPU / F_BUS) > 2
+	__asm__ volatile ("nop");
+	#endif
+	#if (F_CPU / F_BUS) > 3
+	__asm__ volatile ("nop");
+	#endif
+	#if (F_CPU / F_BUS) > 4
+	__asm__ volatile ("nop");
+	#endif
+	#if (F_CPU / F_BUS) > 5
+	__asm__ volatile ("nop");
+	#endif
+	#if (F_CPU / F_BUS) > 6
+	__asm__ volatile ("nop");
+	#endif
+	#if (F_CPU / F_BUS) > 7
+	__asm__ volatile ("nop");
+	#endif
+}
+
+#endif

--- a/utility/WatchdogKinetisK.h
+++ b/utility/WatchdogKinetisK.h
@@ -1,0 +1,38 @@
+#ifndef WATCHDOGKINETISK_H
+#define WATCHDOGKINETISK_H
+
+class WatchdogKinetisKseries {
+public:
+    WatchdogKinetisKseries(): setting(0) {}
+
+    // Enable the watchdog timer to reset the machine after a period of time
+    // without any calls to reset().  The passed in period (in milliseconds) is
+    // just a suggestion and a lower value might be picked if the hardware does
+    // not support the exact desired value.
+    //
+    // The actual period (in milliseconds) before a watchdog timer reset is
+    // returned.
+    int enable(int maxPeriodMS = 0);
+
+    // Reset or 'kick' the watchdog timer to prevent a reset of the device.
+    void reset();
+
+    // Completely disable the watchdog timer.
+    void disable();
+
+    // Enter the lowest power sleep mode (using the watchdog timer) for the
+    // desired period of time.  The passed in period (in milliseconds) is
+    // just a suggestion and a lower value might be picked if the hardware does
+    // not support the exact desired value
+    //
+    // The actual period (in milliseconds) that the hardware was asleep will be
+    // returned.
+    //
+    // NOTE: This is currently not implemented on the SAMD21!
+    int sleep(int maxPeriodMS = 0);
+
+private:
+    int setting;
+};
+
+#endif

--- a/utility/WatchdogKinetisL.cpp
+++ b/utility/WatchdogKinetisL.cpp
@@ -1,0 +1,74 @@
+// Be careful to use a platform-specific conditional include to only make the
+// code visible for the appropriate platform.  Arduino will try to compile and
+// link all .cpp files regardless of platform.
+#if defined(__MKL26Z64__)
+
+#include <kinetis.h>
+#include "WatchdogKinetisL.h"
+
+// Normally the watchdog is disabled at startup.  This removes the startup
+// code.  The watchdog will be active with 1024 ms timeout.  Hopefully the
+// user will configure the watchdog and begin resetting it before it causes
+// a reboot.  There is no way to start up without the watchdog and then
+// enable it later...
+extern "C" void startup_early_hook(void) {}
+
+
+// Enable the watchdog timer to reset the machine after a period of time
+// without any calls to reset().  The passed in period (in milliseconds) is
+// just a suggestion and a lower value might be picked if the hardware does
+// not support the exact desired value.
+//
+// The actual period (in milliseconds) before a watchdog timer reset is
+// returned.
+int WatchdogKinetisLseries::enable(int maxPeriodMS)
+{
+	// The watchdog can only be programmed once.  Then it's forever
+	// locked to this setting (until the chip reboots).
+	if (maxPeriodMS <= 0 || maxPeriodMS > 256) {
+		SIM_COPC = 12;
+	} else if (maxPeriodMS > 32) {
+		SIM_COPC = 8;
+	} else {
+		SIM_COPC = 4;
+	}
+	// Read the actual setting.
+	int val = SIM_COPC & 12;
+	if (val == 12) return 1024;
+	if (val == 8) return 256;
+	return 32;
+}
+
+// Reset or 'kick' the watchdog timer to prevent a reset of the device.
+void WatchdogKinetisLseries::reset()
+{
+	__disable_irq();
+	SIM_SRVCOP = 0x55;
+	SIM_SRVCOP = 0xAA;
+	__enable_irq();
+}
+
+// Completely disable the watchdog timer.
+void WatchdogKinetisLseries::disable()
+{
+	// no can do....
+	// The watchdog timer in this chip is write-once.
+	// The chip boots up with the watchdog at 1024 ms.
+	// You only get to configure it once.  Then it
+	// remains locked to that setting, until a reboot.
+}
+
+// Enter the lowest power sleep mode for the desired period of time.  The
+// passed in period (in milliseconds) is just a suggestion and a lower value
+// might be picked if the hardware does not support the exact desired value
+//
+// The actual period (in milliseconds) that the hardware was asleep will be
+// returned.
+int WatchdogKinetisLseries::sleep(int maxPeriodMS)
+{
+	if (maxPeriodMS <= 0) return 0;
+	// TODO....
+	return 0;
+}
+
+#endif

--- a/utility/WatchdogKinetisL.h
+++ b/utility/WatchdogKinetisL.h
@@ -1,0 +1,35 @@
+#ifndef WATCHDOGKINETISL_H
+#define WATCHDOGKINETISL_H
+
+class WatchdogKinetisLseries {
+public:
+    WatchdogKinetisLseries() {}
+
+    // Enable the watchdog timer to reset the machine after a period of time
+    // without any calls to reset().  The passed in period (in milliseconds) is
+    // just a suggestion and a lower value might be picked if the hardware does
+    // not support the exact desired value.
+    //
+    // The actual period (in milliseconds) before a watchdog timer reset is
+    // returned.
+    int enable(int maxPeriodMS = 0);
+
+    // Reset or 'kick' the watchdog timer to prevent a reset of the device.
+    void reset();
+
+    // Completely disable the watchdog timer.
+    void disable();
+
+    // Enter the lowest power sleep mode (using the watchdog timer) for the
+    // desired period of time.  The passed in period (in milliseconds) is
+    // just a suggestion and a lower value might be picked if the hardware does
+    // not support the exact desired value
+    //
+    // The actual period (in milliseconds) that the hardware was asleep will be
+    // returned.
+    //
+    // NOTE: This is currently not implemented on the SAMD21!
+    int sleep(int maxPeriodMS = 0);
+};
+
+#endif


### PR DESCRIPTION
This adds hardware defs for the 32 bit Teensy boards.

The watchdog on Teensy LC has a write-once hardware register.  I did the best I could to map it onto this API which assumes the watchdog can be disabled and reconfigured.  It works, with some caveats.