### PR TITLE
Document how to reconnect the USB for 32u4 based boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 Arduino library to use the watchdog timer for system reset and low power sleep.
 
 Currently supports the following hardware:
+
 *  Arduino Uno or other ATmega328P-based boards.
 *  Arduino Mega or other ATmega2560- or 1280-based boards.
 *  Arduino Zero, Adafruit Feather M0 (ATSAMD21). Requires Adafruit_ASFcore library -- install using Arduino Library Manager.
-*  Arduino Leonardo or other 32u4-based boards (e.g. Adafruit Feather) WITH CAVEAT: USB Serial connection is clobbered on sleep; if sketch does not require Serial comms, this is not a concern. The example sketches all print to Serial and appear frozen, but the logic does otherwise continue to run.
+*  Arduino Leonardo or other 32u4-based boards (e.g. Adafruit Feather) WITH CAVEAT: USB Serial connection is clobbered on sleep; if sketch does not require Serial comms, this is not a concern. The example sketches all print to Serial and appear frozen, but the logic does otherwise continue to run. You can restore the USB serial connection after waking up using `USBDevice.attach();` and then reconnect to USB serial from the host machine.
 *  Partial support for Teensy 3.X and LC (watchdog, no sleep).
 
 Adafruit Trinket and other boards using ATtiny MCUs are NOT supported.

--- a/examples/Sleep/Sleep.ino
+++ b/examples/Sleep/Sleep.ino
@@ -30,6 +30,10 @@ void loop() {
   // milliseconds).
   // int sleepMS = Watchdog.sleep(1000);  // Sleep for up to 1 second.
 
+  // For 32u4 based boards which lose the USB connection, reattach the connection.
+  // The host will also need to reattach to the Serial monitor.
+  // USBDevice.attach();
+
   Serial.print("I'm awake now!  I slept for ");
   Serial.print(sleepMS, DEC);
   Serial.println(" milliseconds.");


### PR DESCRIPTION
For 32u4 based boards the SleepDog library is [cleaning detaching from the USB](https://github.com/jeraymond/Adafruit_SleepyDog/blob/master/utility/WatchdogAVR.cpp#L66). This change documents how to re-attach the USB connection for both the board and the host.