### PR TITLE
add nrf port

### DIFF
--- a/Adafruit_SleepyDog.h
+++ b/Adafruit_SleepyDog.h
@@ -19,6 +19,9 @@
   // Teensy LC watchdog support.
   #include "utility/WatchdogKinetisL.h"
   typedef WatchdogKinetisLseries WatchdogType;
+#elif defined(NRF52832_XXAA) || defined(NRF52840_XXAA)
+  #include "utility/WatchdogNRF.h"
+  typedef WatchdogNRF WatchdogType;
 #else
   #error Unsupported platform for the Adafruit Watchdog library!
 #endif

--- a/utility/WatchdogNRF.cpp
+++ b/utility/WatchdogNRF.cpp
@@ -1,0 +1,65 @@
+#if defined(NRF52832_XXAA) || defined(NRF52840_XXAA)
+
+#include "Arduino.h"
+#include "WatchdogNRF.h"
+#include "nrf_wdt.h"
+
+WatchdogNRF::WatchdogNRF()
+{
+  _wdto = -1;
+}
+
+int WatchdogNRF::enable(int maxPeriodMS)
+{
+  if (maxPeriodMS < 0) return 0;
+
+  // cannot change wdt config register once it is started
+  // return previous configured timeout
+  if ( nrf_wdt_started() ) return _wdto;
+
+  // WDT run when CPU is sleep
+  nrf_wdt_behaviour_set(NRF_WDT_BEHAVIOUR_RUN_SLEEP);
+  nrf_wdt_reload_value_set((maxPeriodMS * 32768) / 1000);
+
+  // use channel 0
+  nrf_wdt_reload_request_enable(NRF_WDT_RR0);
+
+  // Start WDT
+  // After started CRV, RREN and CONFIG is blocked
+  // There is no way to stop/disable watchdog using source code
+  // It can only be reset by WDT timeout, Pin reset, Power reset
+  nrf_wdt_task_trigger(NRF_WDT_TASK_START);
+
+  _wdto = maxPeriodMS;
+
+  return maxPeriodMS;
+}
+
+
+void WatchdogNRF::reset()
+{
+  nrf_wdt_reload_request_set(NRF_WDT_RR0);
+}
+
+void WatchdogNRF::disable()
+{
+  // There is no way to stop/disable watchdog using source code
+}
+
+int WatchdogNRF::sleep(int maxPeriodMS)
+{
+  if (maxPeriodMS < 0) return 0;
+
+  // Mimic AVR to use 8 seconds.
+  if ( maxPeriodMS == 0 ) maxPeriodMS = 8000;
+
+#ifdef ARDUINO_NRF52_ADAFRUIT
+  // Bluefruit freeRTOS tickless implementation will
+  // automatically put CPU into low power mode with delay()
+  delay(maxPeriodMS);
+#endif
+
+  return maxPeriodMS;
+}
+
+#endif

--- a/utility/WatchdogNRF.h
+++ b/utility/WatchdogNRF.h
@@ -1,0 +1,37 @@
+#ifndef WATCHDOGNRF_H_
+#define WATCHDOGNRF_H_
+
+class WatchdogNRF
+{
+  public:
+    WatchdogNRF();
+
+    // Enable the watchdog timer to reset the machine after a period of time
+    // without any calls to reset().  The passed in period (in milliseconds) is
+    // just a suggestion and a lower value might be picked if the hardware does
+    // not support the exact desired value.
+    //
+    // The actual period (in milliseconds) before a watchdog timer reset is
+    // returned.
+    int enable(int maxPeriodMS = 0);
+
+    // Reset or 'kick' the watchdog timer to prevent a reset of the device.
+    void reset();
+
+    // Completely disable the watchdog timer.
+    void disable();
+
+    // Enter the lowest power sleep mode (using the watchdog timer) for the
+    // desired period of time.  The passed in period (in milliseconds) is
+    // just a suggestion and a lower value might be picked if the hardware does
+    // not support the exact desired value
+    //
+    // The actual period (in milliseconds) that the hardware was asleep will be
+    // returned.
+    int sleep(int maxPeriodMS = 0);
+
+  private:
+    int _wdto;
+};
+
+#endif /* WATCHDOGNRF_H_ */


### PR DESCRIPTION
- for nRF5x, once WDT is started it cannot be disabled/stop/re-configured, we can only re-configure it after a reset e.g watchdog reset, pin reset, power reset, brown-out reset (even soft reset NVIC Reset won't help). 
- Sleep() ~ delay(): Bluefruit freeRTOS tickless implementation will automatically put MCU in low-power mode when there is no active task/interrupt. Most of the time when delay() is called the CPU will enter sleep mode ( it could wake up to response for usb or ble event), but then back to sleep until time is expired.