### PR TITLE
Change to allow the SAMD51 to enter deep sleep

### DIFF
--- a/utility/WatchdogSAMD.cpp
+++ b/utility/WatchdogSAMD.cpp
@@ -222,7 +222,7 @@ void WatchdogSAMD::_initialize_wdt() {
     USB->DEVICE.CTRLA.bit.ENABLE = 0;         // Disable the USB peripheral
     while(USB->DEVICE.SYNCBUSY.bit.ENABLE);   // Wait for synchronization
     USB->DEVICE.CTRLA.bit.RUNSTDBY = 0;       // Deactivate run on standby
-    USB->DEVICE.CTRLA.bit.ENABLE = 1;         // Enable USB peripheral
+    USB->DEVICE.CTRLA.bit.ENABLE = 1;         // Enable the USB peripheral
     while(USB->DEVICE.SYNCBUSY.bit.ENABLE);   // Wait for synchronization
 #else
     // Generic clock generator 2, divisor = 32 (2^(DIV+1))

--- a/utility/WatchdogSAMD.cpp
+++ b/utility/WatchdogSAMD.cpp
@@ -21,6 +21,11 @@ int WatchdogSAMD::enable(int maxPeriodMS, bool isForSleep) {
     if(!_initialized) _initialize_wdt();
 
 #if defined(__SAMD51__)
+    USB->DEVICE.CTRLA.bit.ENABLE = 0;         // Disable the USB peripheral
+    while(USB->DEVICE.SYNCBUSY.bit.ENABLE);   // Wait for synchronization
+    USB->DEVICE.CTRLA.bit.RUNSTDBY = 0;       // Deactivate run on standby
+    USB->DEVICE.CTRLA.bit.ENABLE = 1;         // Enable USB peripheral
+    while(USB->DEVICE.SYNCBUSY.bit.ENABLE);   // Wait for synchronization
     WDT->CTRLA.reg = 0; // Disable watchdog for config
     while(WDT->SYNCBUSY.reg);
 #else

--- a/utility/WatchdogSAMD.cpp
+++ b/utility/WatchdogSAMD.cpp
@@ -21,11 +21,6 @@ int WatchdogSAMD::enable(int maxPeriodMS, bool isForSleep) {
     if(!_initialized) _initialize_wdt();
 
 #if defined(__SAMD51__)
-    USB->DEVICE.CTRLA.bit.ENABLE = 0;         // Disable the USB peripheral
-    while(USB->DEVICE.SYNCBUSY.bit.ENABLE);   // Wait for synchronization
-    USB->DEVICE.CTRLA.bit.RUNSTDBY = 0;       // Deactivate run on standby
-    USB->DEVICE.CTRLA.bit.ENABLE = 1;         // Enable USB peripheral
-    while(USB->DEVICE.SYNCBUSY.bit.ENABLE);   // Wait for synchronization
     WDT->CTRLA.reg = 0; // Disable watchdog for config
     while(WDT->SYNCBUSY.reg);
 #else
@@ -223,6 +218,12 @@ void WatchdogSAMD::_initialize_wdt() {
     NVIC_EnableIRQ(WDT_IRQn);
 
     while(WDT->SYNCBUSY.reg);
+    
+    USB->DEVICE.CTRLA.bit.ENABLE = 0;         // Disable the USB peripheral
+    while(USB->DEVICE.SYNCBUSY.bit.ENABLE);   // Wait for synchronization
+    USB->DEVICE.CTRLA.bit.RUNSTDBY = 0;       // Deactivate run on standby
+    USB->DEVICE.CTRLA.bit.ENABLE = 1;         // Enable USB peripheral
+    while(USB->DEVICE.SYNCBUSY.bit.ENABLE);   // Wait for synchronization
 #else
     // Generic clock generator 2, divisor = 32 (2^(DIV+1))
     GCLK->GENDIV.reg = GCLK_GENDIV_ID(2) | GCLK_GENDIV_DIV(4);


### PR DESCRIPTION
The SAMD51 core currently doesn't allow the microcontroller to sleep using the ARM WFI() function. 

The reason is that SAMD51's USB peripheral is set to Run-On-Standby. Clearing the USB peripheral's RUNSTDBY bit allows the microcontroller to enter deep sleep on receiving the WFI() command.

The SAMD21 by contrast doesn't exhibit this behaviour and remains unaffected, irrespective of the RUNSTDBY bit state (0 or 1).

The suggested change is to the WatchdogSAMD::_initialize_wdt() function in the "WatchdogSAMD.cpp" file.