### PR TITLE
Disable SAMD21 SysTick interrupt during sleep and correct SAMD20/21 defines

### DIFF
--- a/utility/WatchdogSAMD.cpp
+++ b/utility/WatchdogSAMD.cpp
@@ -199,7 +199,7 @@ int WatchdogSAMD::sleep(int maxPeriodMS) {
 
   // Enable standby sleep mode (deepest sleep) and activate.
   // Insights from Atmel ASF library.
-#if (SAMD20 || SAMD21)
+#if (SAMD20_SERIES || SAMD21_SERIES)
   // Don't fully power down flash when in sleep
   NVMCTRL->CTRLB.bit.SLEEPPRM = NVMCTRL_CTRLB_SLEEPPRM_DISABLED_Val;
 #endif
@@ -209,11 +209,19 @@ int WatchdogSAMD::sleep(int maxPeriodMS) {
     ; // Wait for it to take
 #else
   SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
+  // Due to a hardware bug on the SAMD21, the SysTick interrupts become 
+  // active before the flash has powered up from sleep, causing a hard fault.
+  // To prevent this the SysTick interrupts are disabled before entering sleep mode.
+  SysTick->CTRL &= ~SysTick_CTRL_TICKINT_Msk;  // Disable SysTick interrupts
 #endif
 
   __DSB(); // Data sync to ensure outgoing memory accesses complete
   __WFI(); // Wait for interrupt (places device in sleep mode)
 
+#if (SAMD20_SERIES || SAMD21_SERIES)
+  SysTick->CTRL |= SysTick_CTRL_TICKINT_Msk;   // Enable SysTick interrupts
+#endif
+  
   // Code resumes here on wake (WDT early warning interrupt).
   // Bug: the return value assumes the WDT has run its course;
   // incorrect if the device woke due to an external interrupt.


### PR DESCRIPTION
This pull request addresses two separate issues.

The first is in response to the issue: "strange reset on Feather M0 after random minutes", raised here: https://github.com/adafruit/Adafruit_SleepyDog/issues/9.

Disabling the systick timer interrupt during sleep has previously been discussed on the Microchip/Atmel community forum: https://community.atmel.com/comment/2625116#comment-2625116.

In summary, due to a hardware bug on the SAMD21, the SysTick interrupts become active before the flash has powered up from sleep, causing a hard fault after a random time. To prevent this the SysTick interrupts are disabled before entering sleep mode and enabled oncemore after the processor has woken up:

```
SysTick->CTRL &= ~SysTick_CTRL_TICKINT_Msk;  // Disable SysTick interrupts
__DSB();   // Data sync to ensure outgoing memory accesses complete
__WFI();   // Wait for interrupt (places device in sleep mode)
SysTick->CTRL |= SysTick_CTRL_TICKINT_Msk;   // Enable SysTick interrupts
```

The second issue, is that to the best of my knowledge the SAMD20 and SAMD21 definitions do not exist, either in the included "sam.h" file or anywhere else. I've tested the definitions with a small sketch and SAMD21 remains undefined. This means that the line that prevents the RAM from powering down during sleep never gets called:

```
#if (SAMD20 || SAMD21)
  // Don't fully power down flash when in sleep
  NVMCTRL->CTRLB.bit.SLEEPPRM = NVMCTRL_CTRLB_SLEEPPRM_DISABLED_Val;
#endif
```

The "sam.h" file does however provide a SAMD21_SERIES define and earlier versions also include SAMD20_SERIES, these encompass all the SAMD20/SAMD21 variants:

```
#if (SAMD20_SERIES || SAMD21_SERIES)
```

I've tested the code on a SAMD21, however I'm unable to test on a SAMD20. I've assumed that the SAMD20 also being an ARM Cortex M0+ exhibits the same behaviour as the SAMD21. The SAMD51 code remains unaffected by these changes.