### PR TITLE
Add Feather M4 (ATSAMD51) support to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Currently supports the following hardware:
 *  Arduino Uno or other ATmega328P-based boards.
 *  Arduino Mega or other ATmega2560- or 1280-based boards.
 *  Arduino Zero, Adafruit Feather M0 (ATSAMD21).
+*  Adafruit Feather M4 (ATSAMD51).
 *  Arduino Leonardo or other 32u4-based boards (e.g. Adafruit Feather) WITH CAVEAT: USB Serial connection is clobbered on sleep; if sketch does not require Serial comms, this is not a concern. The example sketches all print to Serial and appear frozen, but the logic does otherwise continue to run. You can restore the USB serial connection after waking up using `USBDevice.attach();` and then reconnect to USB serial from the host machine.
 *  Partial support for Teensy 3.X and LC (watchdog, no sleep).
 


### PR DESCRIPTION
I initially passed on using this wonderful library for my Feather M4 as I saw no mention of the board being supported in the README, but lo and behold, I found #19 through Google and realized there is support!

The library works for me :shrug: on the Feather M4, so it would be awesome if the README mentioned the board to help fellow library-searchers.