### PR TITLE
Hiding isForSleep parameter in WatchdogSAMD::enable()

### DIFF
--- a/utility/WatchdogSAMD.cpp
+++ b/utility/WatchdogSAMD.cpp
@@ -8,6 +8,10 @@
 #include "WatchdogSAMD.h"
 #include <sam.h>
 
+int WatchdogSAMD::enable(int maxPeriodMS) {
+  return this->enable(maxPeriodMS, false);
+}
+
 int WatchdogSAMD::enable(int maxPeriodMS, bool isForSleep) {
   // Enable the watchdog with a period up to the specified max period in
   // milliseconds.

--- a/utility/WatchdogSAMD.h
+++ b/utility/WatchdogSAMD.h
@@ -11,13 +11,9 @@ public:
   // without any calls to reset().  The passed in period (in milliseconds)
   // is just a suggestion and a lower value might be picked if the hardware
   // does not support the exact desired value.
-  // User code should NOT set the 'isForSleep' argument either way --
-  // it's used internally by the library, but your sketch should leave this
-  // out when calling enable(), just let the default have its way.
-  //
   // The actual period (in milliseconds) before a watchdog timer reset is
   // returned.
-  int enable(int maxPeriodMS = 0, bool isForSleep = false);
+  int enable(int maxPeriodMS = 0);
 
   // Reset or 'kick' the watchdog timer to prevent a reset of the device.
   void reset();
@@ -39,6 +35,8 @@ public:
 
 private:
   void _initialize_wdt();
+
+  int enable(int maxPeriodMS, bool isForSleep);
 
   bool _initialized;
 };


### PR DESCRIPTION
Replacing:
public:
  int WatchdogSAMD::enable(int maxPeriodMS = 0, bool isForSleep = false);

By:
public:
  int WatchdogSAMD::enable(int maxPeriodMS = 0);
private:
  int WatchdogSAMD::enable(int maxPeriodMS, bool isForSleep);
