### PR TITLE
Update WatchdogAVR.cpp

### DIFF
--- a/utility/WatchdogAVR.cpp
+++ b/utility/WatchdogAVR.cpp
@@ -75,9 +75,6 @@ int WatchdogAVR::sleep(int maxPeriodMS) {
 
   // Chip is now asleep!
 
-  // Once awakened by the watchdog execution resumes here.
-  // Start by disabling sleep.
-  sleep_disable();
 
   // Check if user had the watchdog enabled before sleep and re-enable it.
   if (_wdto != -1)


### PR DESCRIPTION
My arduino IDE includes the file arduino-1.8.13/hardware/tools/avr/avr/include/avr/sleep.h which contains already a `sleep_disable()` call, see the definition below. So it can be removed? Or is this done differently in the various boards?


```
#define sleep_mode() \
do {                 \
    sleep_enable();  \
    sleep_cpu();     \
    sleep_disable(); \
} while (0)```