### PR TITLE
Add support for ESP32

### DIFF
--- a/Adafruit_SleepyDog.h
+++ b/Adafruit_SleepyDog.h
@@ -28,6 +28,9 @@ typedef WatchdogKinetisLseries WatchdogType;
 #elif defined(NRF52_SERIES)
 #include "utility/WatchdogNRF.h"
 typedef WatchdogNRF WatchdogType;
+#elif defined(ARDUINO_ARCH_ESP32)
+#include "utility/WatchdogESP32.h"
+typedef WatchdogESP32 WatchdogType;
 #else
 #error Unsupported platform for the Adafruit Watchdog library!
 #endif

--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ Currently supports the following hardware:
 *  Arduino Leonardo or other 32u4-based boards (e.g. Adafruit Feather) WITH CAVEAT: USB Serial connection is clobbered on sleep; if sketch does not require Serial comms, this is not a concern. The example sketches all print to Serial and appear frozen, but the logic does otherwise continue to run. You can restore the USB serial connection after waking up using `USBDevice.attach();` and then reconnect to USB serial from the host machine.
 *  Partial support for Teensy 3.X and LC (watchdog, no sleep).
 *  ATtiny 24/44/84 and 25/45/85
+*  ESP32, ESP32-S2

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit SleepyDog Library
-version=1.4.0
+version=1.5.0
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino library to use the watchdog timer for system reset and low power sleep.

--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Arduino library to use the watchdog timer for system reset and low powe
 paragraph=Arduino library to use the watchdog timer for system reset and low power sleep.
 category=Other
 url=https://github.com/adafruit/Adafruit_SleepyDog
-architectures=avr,samd,nrf52,teensy
+architectures=avr,samd,nrf52,teensy, esp32

--- a/utility/WatchdogESP32.cpp
+++ b/utility/WatchdogESP32.cpp
@@ -3,8 +3,6 @@
 #include "WatchdogESP32.h"
 #include <esp_task_wdt.h>
 
-WatchdogESP32::WatchdogESP32() { _wdto = -1; }
-
 int WatchdogESP32::enable(int maxPeriodMS) {
   if (maxPeriodMS < 0)
     return 0;
@@ -17,7 +15,6 @@ int WatchdogESP32::enable(int maxPeriodMS) {
   esp_task_wdt_add(NULL);
 
   _wdto = maxPeriodMS;
-
   return maxPeriodMS;
 }
 

--- a/utility/WatchdogESP32.cpp
+++ b/utility/WatchdogESP32.cpp
@@ -1,18 +1,24 @@
 #if defined(ARDUINO_ARCH_ESP32)
 
 #include "WatchdogESP32.h"
-#include <esp_task_wdt.h>
+#include "esp_task_wdt.h"
+#include "esp_sleep.h"
 
 int WatchdogESP32::enable(int maxPeriodMS) {
   if (maxPeriodMS < 0)
     return 0;
 
-  // Enable the TWDT
-  // and execute the esp32 panic handler when TWDT times out
-  esp_task_wdt_init((uint32_t)maxPeriodMS, true);
+  // ESP32 expects TWDT in seconds
+  uint32_t maxPeriod = maxPeriodMS / 1000;
+  // Enable the TWDT and execute the esp32 panic handler when TWDT times out
+  esp_err_t = esp_task_wdt_init(maxPeriod, true);
+  if (err != ESP_OK)
+    return 0; // Initialization failed due to lack of memory
 
   // NULL to subscribe the current running task to the TWDT
-  esp_task_wdt_add(NULL);
+  err = esp_task_wdt_add(NULL);
+  if (err != ESP_OK)
+    return 0;
 
   _wdto = maxPeriodMS;
   return maxPeriodMS;
@@ -30,7 +36,22 @@ void WatchdogESP32::disable() {
   esp_task_wdt_delete(NULL);
 }
 
-// not implemented
-void WatchdogESP32::sleep() {}
+int WatchdogESP32::sleep(int maxPeriodMS) {
+  if (maxPeriodMS < 0)
+      return 0;
+  // Convert from MS to microseconds
+  uint64_t sleepTime = maxPeriodMS * 1000;
+  // Enable wakeup by timer
+  esp_err_t err = esp_sleep_enable_timer_wakeup(sleepTime);
+  if (err != ESP_OK) {
+      return 0; // sleepTime is out of range
+  }
+  // Enter light sleep with the timer wakeup option configured
+  err = esp_light_sleep_start();
+  if (err != ESP_OK) {
+    return 0; // ESP_ERR_INVALID_STATE if WiFi or BT is not stopped
+  }
+  return maxPeriodMS;
+}
 
 #endif // ARDUINO_ARCH_ESP32

--- a/utility/WatchdogESP32.cpp
+++ b/utility/WatchdogESP32.cpp
@@ -1,0 +1,39 @@
+#if defined(ARDUINO_ARCH_ESP32)
+
+#include "WatchdogESP32.h"
+#include <esp_task_wdt.h>
+
+WatchdogESP32::WatchdogESP32() { _wdto = -1; }
+
+int WatchdogESP32::enable(int maxPeriodMS) {
+  if (maxPeriodMS < 0)
+    return 0;
+
+  // Enable the TWDT
+  // and execute the esp32 panic handler when TWDT times out
+  esp_task_wdt_init((uint32_t)maxPeriodMS, true);
+
+  // NULL to subscribe the current running task to the TWDT
+  esp_task_wdt_add(NULL);
+
+  _wdto = maxPeriodMS;
+
+  return maxPeriodMS;
+}
+
+void WatchdogESP32::reset() {
+  // Reset the Task Watchdog Timer (TWDT) on behalf
+  // of the currently running task.
+  // NOTE: This blindly resets the TWDT and does not return the esp_err.
+  esp_task_wdt_reset();
+}
+
+void WatchdogESP32::disable() {
+  // Unsubscribes the current running task from the TWDT
+  esp_task_wdt_delete(NULL);
+}
+
+// not implemented
+void WatchdogESP32::sleep() {}
+
+#endif // ARDUINO_ARCH_ESP32

--- a/utility/WatchdogESP32.cpp
+++ b/utility/WatchdogESP32.cpp
@@ -1,9 +1,19 @@
 #if defined(ARDUINO_ARCH_ESP32)
 
 #include "WatchdogESP32.h"
-#include "esp_task_wdt.h"
 #include "esp_sleep.h"
+#include "esp_task_wdt.h"
 
+/**************************************************************************/
+/*!
+    @brief  Initializes the ESP32's Task Watchdog Timer (TWDT) and
+            subscribes to the current running task.
+    @param    maxPeriodMS
+              Timeout period of TWDT in seconds
+    @return The actual period (in milliseconds) before a watchdog timer
+            reset is returned. 0 otherwise.
+*/
+/**************************************************************************/
 int WatchdogESP32::enable(int maxPeriodMS) {
   if (maxPeriodMS < 0)
     return 0;
@@ -24,27 +34,45 @@ int WatchdogESP32::enable(int maxPeriodMS) {
   return maxPeriodMS;
 }
 
+/**************************************************************************/
+/*!
+    @brief  Resets the Task Watchdog Timer (TWDT) on behalf
+            of the currently running task.
+*/
+/**************************************************************************/
 void WatchdogESP32::reset() {
-  // Reset the Task Watchdog Timer (TWDT) on behalf
-  // of the currently running task.
   // NOTE: This blindly resets the TWDT and does not return the esp_err.
   esp_task_wdt_reset();
 }
 
-void WatchdogESP32::disable() {
-  // Unsubscribes the current running task from the TWDT
-  esp_task_wdt_delete(NULL);
-}
+/**************************************************************************/
+/*!
+    @brief  Disables the TWDT by unsubscribing the currently running task
+            from the TWDT.
+*/
+/**************************************************************************/
+void WatchdogESP32::disable() { esp_task_wdt_delete(NULL); }
 
+/**************************************************************************/
+/*!
+    @brief  Configures the ESP32 to enter a low-power sleep mode for a
+            desired amount of time.
+    @param    maxPeriodMS
+              Time to sleep the ESP32, in millis.
+    @return The actual period (in milliseconds) that the hardware was
+            asleep will be returned. Otherwise, 0 will be returned if the
+            hardware could not enter the low-power mode.
+*/
+/**************************************************************************/
 int WatchdogESP32::sleep(int maxPeriodMS) {
   if (maxPeriodMS < 0)
-      return 0;
+    return 0;
   // Convert from MS to microseconds
   uint64_t sleepTime = maxPeriodMS * 1000;
   // Enable wakeup by timer
   esp_err_t err = esp_sleep_enable_timer_wakeup(sleepTime);
   if (err != ESP_OK) {
-      return 0; // sleepTime is out of range
+    return 0; // sleepTime is out of range
   }
   // Enter light sleep with the timer wakeup option configured
   err = esp_light_sleep_start();

--- a/utility/WatchdogESP32.cpp
+++ b/utility/WatchdogESP32.cpp
@@ -1,8 +1,6 @@
 #if defined(ARDUINO_ARCH_ESP32)
 
 #include "WatchdogESP32.h"
-#include "esp_sleep.h"
-#include "esp_task_wdt.h"
 
 /**************************************************************************/
 /*!
@@ -21,7 +19,7 @@ int WatchdogESP32::enable(int maxPeriodMS) {
   // ESP32 expects TWDT in seconds
   uint32_t maxPeriod = maxPeriodMS / 1000;
   // Enable the TWDT and execute the esp32 panic handler when TWDT times out
-  esp_err_t = esp_task_wdt_init(maxPeriod, true);
+  esp_err_t err = esp_task_wdt_init(maxPeriod, true);
   if (err != ESP_OK)
     return 0; // Initialization failed due to lack of memory
 

--- a/utility/WatchdogESP32.h
+++ b/utility/WatchdogESP32.h
@@ -1,26 +1,32 @@
+/*!
+ * @file WatchdogESP32.h
+ *
+ * Support for ESP32 TWDT and low-power sleep modes.
+ *
+ * Adafruit invests time and resources providing this open source code,
+ * please support Adafruit and open-source hardware by purchasing
+ * products from Adafruit!
+ *
+ * Written by Brent Rubell for Adafruit Industries.
+ *
+ * MIT License, all text here must be included in any redistribution.
+ *
+ */
 #ifndef WATCHDOGESP32_H_
 #define WATCHDOGESP32_H_
 
+/**************************************************************************/
+/*!
+    @brief  Class that contains functions for interacting with the ESP32's
+            WDT and low-power sleep functions.
+*/
+/**************************************************************************/
 class WatchdogESP32 {
 public:
-  WatchdogESP32() : _wdto(-1) {};
-
-  // Enable the watchdog timer to reset the machine after a period of time
-  // without any calls to reset().  The passed in period (in milliseconds) is
-  // just a suggestion and a lower value might be picked if the hardware does
-  // not support the exact desired value.
-  //
-  // The actual period (in milliseconds) before a watchdog timer reset is
-  // returned.
+  WatchdogESP32() : _wdto(-1){};
   int enable(int maxPeriodMS = 0);
-
-  // Reset or 'kick' the watchdog timer to prevent a reset of the device.
   void reset();
-
-  // Completely disable the watchdog timer.
   void disable();
-
-  // Enter ESP32 Deep-sleep mode
   int sleep(int maxPeriodMS = 0);
 
 private:

--- a/utility/WatchdogESP32.h
+++ b/utility/WatchdogESP32.h
@@ -20,7 +20,8 @@ public:
   // Completely disable the watchdog timer.
   void disable();
 
-  void sleep() __attribute__((error("ESP32 Sleep not implemented!")));
+  // Enter ESP32 Deep-sleep mode
+  int sleep(int maxPeriodMS = 0);
 
 private:
   int _wdto;

--- a/utility/WatchdogESP32.h
+++ b/utility/WatchdogESP32.h
@@ -1,9 +1,10 @@
-#ifndef WATCHDOGESP32_H
-#define WATCHDOGESP32_H
+#ifndef WATCHDOGESP32_H_
+#define WATCHDOGESP32_H_
 
 class WatchdogESP32 {
 public:
-  WatchdogESP32();
+  WatchdogESP32() : _wdto(-1) {};
+
   // Enable the watchdog timer to reset the machine after a period of time
   // without any calls to reset().  The passed in period (in milliseconds) is
   // just a suggestion and a lower value might be picked if the hardware does
@@ -23,6 +24,6 @@ public:
 
 private:
   int _wdto;
-}
+};
 
 #endif // WATCHDOGESP32_H

--- a/utility/WatchdogESP32.h
+++ b/utility/WatchdogESP32.h
@@ -14,6 +14,8 @@
  */
 #ifndef WATCHDOGESP32_H_
 #define WATCHDOGESP32_H_
+#include "esp_sleep.h"
+#include "esp_task_wdt.h"
 
 /**************************************************************************/
 /*!

--- a/utility/WatchdogESP32.h
+++ b/utility/WatchdogESP32.h
@@ -1,0 +1,28 @@
+#ifndef WATCHDOGESP32_H
+#define WATCHDOGESP32_H
+
+class WatchdogESP32 {
+public:
+  WatchdogESP32();
+  // Enable the watchdog timer to reset the machine after a period of time
+  // without any calls to reset().  The passed in period (in milliseconds) is
+  // just a suggestion and a lower value might be picked if the hardware does
+  // not support the exact desired value.
+  //
+  // The actual period (in milliseconds) before a watchdog timer reset is
+  // returned.
+  int enable(int maxPeriodMS = 0);
+
+  // Reset or 'kick' the watchdog timer to prevent a reset of the device.
+  void reset();
+
+  // Completely disable the watchdog timer.
+  void disable();
+
+  void sleep() __attribute__((error("ESP32 Sleep not implemented!")));
+
+private:
+  int _wdto;
+}
+
+#endif // WATCHDOGESP32_H


### PR DESCRIPTION
Adds SleepDog support for the ESP32
* Uses the ESP32's as the Watchdog Timer (TWDT) for WDT-support since it can be configured during runtime.
  * Defaults to utilizing the current running task as a subscription for the TWDT. 
  * Executes the ESP32's panic-handler TWDT times out
* Adds timer-based low-power-sleep support for ESP32.

----

Tested with: Adafruit ESP32 Feather

BasicUsage
```
11:22:40.250 -> Watchdog Library Demo!
11:22:40.250 -> 
11:22:40.250 -> Enabled the watchdog with max countdown of 4000 milliseconds!
11:22:40.250 -> 
11:22:40.250 -> Looping ten times while resetting the watchdog...
11:22:40.250 -> Loop #1
11:22:41.264 -> Loop #2
11:22:42.270 -> Loop #3
11:22:43.248 -> Loop #4
11:22:44.262 -> Loop #5
11:22:45.236 -> Loop #6
11:22:46.259 -> Loop #7
11:22:47.239 -> Loop #8
11:22:48.244 -> Loop #9
11:22:49.266 -> Loop #10
11:22:50.251 -> 
11:22:50.251 -> Get ready, the watchdog will reset in 4000 milliseconds!
11:22:50.251 -> 
11:22:54.295 -> E (28103) task_wdt: Task watchdog got triggered. The following tasks did not reset the watchdog in time:
11:22:54.295 -> E (28103) task_wdt:  - loopTask (CPU 1)
11:22:54.295 -> E (28103) task_wdt: Tasks currently running:
11:22:54.295 -> E (28103) task_wdt: CPU 0: IDLE
11:22:54.295 -> E (28103) task_wdt: CPU 1: IDLE
11:22:54.295 -> E (28103) task_wdt: Aborting.
11:22:54.295 -> 
11:22:54.295 -> abort() was called at PC 0x400d5107 on core 0
11:22:54.295 -> 
11:22:54.295 -> 
11:22:54.295 -> Backtrace:0x400d5bc5:0x3ffbe7900x40086f91:0x3ffbe7b0 0x4008bf79:0x3ffbe7d0 0x400d5107:0x3ffbe850 0x40084275:0x3ffbe880 0x400e9f83:0x3ffbd3a0 0x400d5a02:0x3ffbd3c0 0x400882c0:0x3ffbd3e0 
11:22:54.295 -> 
11:22:54.295 -> 
11:22:54.295 -> 
11:22:54.295 -> 
11:22:54.295 -> ELF file SHA256: 0000000000000000
11:22:54.295 -> 
11:22:54.295 -> Rebooting...
11:22:54.332 -> ets Jul 29 2019 12:21:46
11:22:54.332 -> 
11:22:54.332 -> rst:0xc (SW_CPU_RESET),boot:0x13 (SPI_FAST_FLASH_BOOT)
11:22:54.332 -> configsip: 0, SPIWP:0xee
11:22:54.332 -> clk_drv:0x00,q_drv:0x00,d_drv:0x00,cs0_drv:0x00,hd_drv:0x00,wp_drv:0x00
11:22:54.332 -> mode:DIO, clock div:1
11:22:54.332 -> load:0x3fff0030,len:1252
11:22:54.332 -> load:0x40078000,len:12732
11:22:54.332 -> load:0x40080400,len:3100
11:22:54.332 -> entry 0x400805ec
11:22:54.436 -> Adafruit Watchdog Library Demo!
```

Sleep
```
11:23:49.026 -> Watchdog Library Sleep Demo!
11:23:49.026 -> 
11:23:49.026 -> Going to sleep in one second...
11:23:51.033 -> I'm awake now! I slept for 1000 milliseconds.
```
