### PR TITLE
Add support for Raspberry Pi Pico Arduino core

### DIFF
--- a/Adafruit_SleepyDog.h
+++ b/Adafruit_SleepyDog.h
@@ -34,6 +34,9 @@ typedef WatchdogESP32 WatchdogType;
 #elif defined(ARDUINO_ARCH_ESP8266)
 #include "utility/WatchdogESP8266.h"
 typedef WatchdogESP8266 WatchdogType;
+#elif defined(ARDUINO_RASPBERRY_PI_PICO) || defined(ARDUINO_RASPBERRY_PI_PICO_W)
+#include "utility/WatchdogRP2040.h"
+typedef WatchdogRP2040 WatchdogType;
 #else
 #error Unsupported platform for the Adafruit Watchdog library!
 #endif

--- a/Adafruit_SleepyDog.h
+++ b/Adafruit_SleepyDog.h
@@ -34,7 +34,7 @@ typedef WatchdogESP32 WatchdogType;
 #elif defined(ARDUINO_ARCH_ESP8266)
 #include "utility/WatchdogESP8266.h"
 typedef WatchdogESP8266 WatchdogType;
-#elif defined(ARDUINO_RASPBERRY_PI_PICO) || defined(ARDUINO_RASPBERRY_PI_PICO_W)
+#elif defined(ARDUINO_ARCH_RP2040)
 #include "utility/WatchdogRP2040.h"
 typedef WatchdogRP2040 WatchdogType;
 #else

--- a/examples/BasicUsage/BasicUsage.ino
+++ b/examples/BasicUsage/BasicUsage.ino
@@ -40,7 +40,8 @@ void setup() {
   }
   Serial.println();
 
-#ifndef NRF52_SERIES // cannot disable nRF's WDT
+// can not disable NRF or RP2040 wdt once enabled
+#if not defined(NRF52_SERIES) || defined(ARDUINO_ARCH_RP2040)
   // Disable the watchdog entirely by calling Watchdog.disable();
   Watchdog.disable();
 #endif

--- a/examples/BasicUsage/BasicUsage.ino
+++ b/examples/BasicUsage/BasicUsage.ino
@@ -41,7 +41,7 @@ void setup() {
   Serial.println();
 
 // can not disable NRF or RP2040 wdt once enabled
-#if not defined(NRF52_SERIES) || defined(ARDUINO_ARCH_RP2040)
+#if !defined(NRF52_SERIES) || !defined(ARDUINO_ARCH_RP2040)
   // Disable the watchdog entirely by calling Watchdog.disable();
   Watchdog.disable();
 #endif

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=Adafruit SleepyDog Library
-version=1.6.1
+version=1.6.2
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino library to use the watchdog timer for system reset and low power sleep.
 paragraph=Arduino library to use the watchdog timer for system reset and low power sleep.
 category=Other
 url=https://github.com/adafruit/Adafruit_SleepyDog
-architectures=avr,samd,nrf52,teensy,esp32,esp8266
+architectures=avr,samd,nrf52,teensy,esp32,esp8266,rp2040

--- a/utility/WatchdogRP2040.cpp
+++ b/utility/WatchdogRP2040.cpp
@@ -53,11 +53,9 @@ void WatchdogRP2040::disable() {}
 int WatchdogRP2040::sleep(int maxPeriodMS) {
   if (maxPeriodMS < 0)
     return 0;
-  // Convert from MS to microseconds
-  uint64_t sleepTime = maxPeriodMS * 1000;
 
-  // perform a lower power (WFE) sleep
-  sleep_us(sleepTime);
+  // perform a lower power (WFE) sleep (pico-core calls sleep_ms(sleepTime))
+  delay(maxPeriodMS);
 
   return maxPeriodMS;
 }

--- a/utility/WatchdogRP2040.cpp
+++ b/utility/WatchdogRP2040.cpp
@@ -1,0 +1,65 @@
+#if defined(ARDUINO_RASPBERRY_PI_PICO) || defined(ARDUINO_RASPBERRY_PI_PICO_W)
+
+#include "WatchdogRP2040.h"
+
+/**********************************************************************************************/
+/*!
+    @brief  Initializes the RP2040's hardware watchdog timer.
+    @param    maxPeriodMS
+              Timeout period of WDT in milliseconds
+    @return The actual period (in milliseconds) before a watchdog timer
+            reset is returned, 0 otherwise.
+*/
+/**********************************************************************************************/
+int WatchdogRP2040::enable(int maxPeriodMS) {
+  if (maxPeriodMS < 0)
+    return 0;
+
+  // Enables the RP2040's hardware WDT with maxPeriodMS delay
+  // (wdt should be updated every maxPeriodMS ms) and 
+  // enables pausing the WDT on debugging when stepping thru
+  watchdog_enable(maxPeriodMS, 1);
+
+  _wdto = maxPeriodMS;
+  return maxPeriodMS;
+}
+
+/**************************************************************************/
+/*!
+    @brief  Reload the watchdog counter with the amount of time set in
+            enable().
+*/
+/**************************************************************************/
+void WatchdogRP2040::reset() { watchdog_update(); }
+
+/**************************************************************************/
+/*!
+    @brief  Once enabled, the RP2040's Watchdog Timer can NOT be disabled.
+*/
+/**************************************************************************/
+void WatchdogRP2040::disable() {}
+
+/**************************************************************************/
+/*!
+    @brief  Configures the RP2040 to enter a lower power (WFE) sleep
+            for a period of time.
+    @param    maxPeriodMS
+              Time to sleep the RP2040, in millis.
+    @return The actual period (in milliseconds) that the hardware was
+            asleep will be returned. Otherwise, 0 will be returned if the
+            hardware could not enter the low-power mode.
+*/
+/**************************************************************************/
+int WatchdogRP2040::sleep(int maxPeriodMS) {
+  if (maxPeriodMS < 0)
+    return 0;
+  // Convert from MS to microseconds
+  uint64_t sleepTime = maxPeriodMS * 1000;
+
+  // perform a lower power (WFE) sleep
+  sleep_us(sleepTime);
+
+  return maxPeriodMS;
+}
+
+#endif // ARDUINO_ARCH_RP2040

--- a/utility/WatchdogRP2040.cpp
+++ b/utility/WatchdogRP2040.cpp
@@ -1,4 +1,4 @@
-#if defined(ARDUINO_RASPBERRY_PI_PICO) || defined(ARDUINO_RASPBERRY_PI_PICO_W)
+#if defined(ARDUINO_ARCH_RP2040)
 
 #include "WatchdogRP2040.h"
 
@@ -16,7 +16,7 @@ int WatchdogRP2040::enable(int maxPeriodMS) {
     return 0;
 
   // Enables the RP2040's hardware WDT with maxPeriodMS delay
-  // (wdt should be updated every maxPeriodMS ms) and 
+  // (wdt should be updated every maxPeriodMS ms) and
   // enables pausing the WDT on debugging when stepping thru
   watchdog_enable(maxPeriodMS, 1);
 

--- a/utility/WatchdogRP2040.h
+++ b/utility/WatchdogRP2040.h
@@ -1,0 +1,40 @@
+/*!
+ * @file WatchdogRP2040.h
+ *
+ * Support for RP2040 Hardware Watchdog Timer API
+ *
+ * Adafruit invests time and resources providing this open source code,
+ * please support Adafruit and open-source hardware by purchasing
+ * products from Adafruit!
+ *
+ * Written by Brent Rubell for Adafruit Industries.
+ *
+ * MIT License, all text here must be included in any redistribution.
+ *
+ */
+#ifndef WATCHDOGRP2040_H_
+#define WATCHDOGRP2040_H_
+
+#include <hardware/watchdog.h>
+#include <pico/time.h>
+
+/**************************************************************************/
+/*!
+    @brief  Class that contains functions for interacting with the
+            RP2040's hardware watchdog timer
+*/
+/**************************************************************************/
+class WatchdogRP2040 {
+public:
+  WatchdogRP2040() : _wdto(-1){};
+  int enable(int maxPeriodMS = 0);
+  void disable()
+      __attribute__((error("RP2040 WDT cannot be disabled once enabled")));
+  void reset();
+  int sleep(int maxPeriodMS = 0);
+
+private:
+  int _wdto;
+};
+
+#endif // WatchdogRP2040_H


### PR DESCRIPTION
Adds SleepyDog support for the Raspberry Pi Pico Arduino core.

Resolves https://github.com/adafruit/Adafruit_SleepyDog/issues/37
Requires https://github.com/earlephilhower/arduino-pico/pull/862 to be merged and released first
Required for Adafruit WipperSnapper 