### PR TITLE
Switch to sleep_ms

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit SleepyDog Library
-version=1.6.2
+version=1.6.3
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino library to use the watchdog timer for system reset and low power sleep.

--- a/utility/WatchdogRP2040.cpp
+++ b/utility/WatchdogRP2040.cpp
@@ -55,7 +55,7 @@ int WatchdogRP2040::sleep(int maxPeriodMS) {
     return 0;
 
   // perform a lower power (WFE) sleep (pico-core calls sleep_ms(sleepTime))
-  delay(maxPeriodMS);
+  sleep_ms(maxPeriodMS);
 
   return maxPeriodMS;
 }


### PR DESCRIPTION
Fixes issue #40 by using the `sleep_ms()` call from the Pico SDK.