### PR TITLE
Resolve possible divide by zero scenario

### DIFF
--- a/utility/WatchdogKinetisK.cpp
+++ b/utility/WatchdogKinetisK.cpp
@@ -72,8 +72,11 @@ static void watchdog_config(int cfg, int val) {
   }
 }
 
-static void one_bus_cycle(void) {
+static void one_bus_cycle(void)
+{
   __asm__ volatile("nop");
+
+#if F_BUS > 0
 #if (F_CPU / F_BUS) > 1
   __asm__ volatile("nop");
 #endif
@@ -94,6 +97,7 @@ static void one_bus_cycle(void) {
 #endif
 #if (F_CPU / F_BUS) > 7
   __asm__ volatile("nop");
+#endif
 #endif
 }
 


### PR DESCRIPTION
Static analysis shows: failed to evaluate #if condition, division/modulo by zero. Test for F_BUS > 0 .

- Scope: Test for F_BUS > 0 in WatchdogKinetisK.cpp

![image](https://user-images.githubusercontent.com/12535732/229268149-9ec9c945-d585-4b54-be71-f8e89b7e3457.png)

- No known limitations

- Tested on SAMD21 & SAME51 custom boards