### PR TITLE
Update for ESP32 IDF v5.x+ 

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit SleepyDog Library
-version=1.6.4
+version=1.6.5
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino library to use the watchdog timer for system reset and low power sleep.

--- a/utility/WatchdogESP32.cpp
+++ b/utility/WatchdogESP32.cpp
@@ -23,7 +23,7 @@ int WatchdogESP32::enable(int maxPeriodMS) {
       .idle_core_mask = 0, // Subscribe to the idle task on the APP CPU
       .trigger_panic = true,
   };
-  // TWDT already initialized, let's just reconfigure it
+  // TWDT already initialized by the RTOS, reconfigure it
   esp_err_t err = esp_task_wdt_reconfigure(&wdt_config);
 #else
   // IDF V4.x and below expect TWDT in seconds

--- a/utility/WatchdogESP32.cpp
+++ b/utility/WatchdogESP32.cpp
@@ -19,7 +19,7 @@ int WatchdogESP32::enable(int maxPeriodMS) {
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 1)
   // Initialize the wdt configuration for ESP-IDF v5.x and above
   esp_task_wdt_config_t wdt_config = {
-      .timeout_ms = maxPeriodMS,
+      .timeout_ms = (uint32_t)maxPeriodMS,
       .idle_core_mask = 0, // Subscribe to the idle task on the APP CPU
       .trigger_panic = true,
   };


### PR DESCRIPTION
IDF v5.x (and above) changes how the TWDT is initialized and configured.

* Added code for ESP32 IDFv5.x and ESP32 BSP 3.x
* Kept backward-compatible code with IDF v4.x for now

Tests OK, resets the TWDT after 4sec.

Tested on Adafruit Feather ESP32 v2

Test Output from `BasicUsage.ino`
```
13:05:00.892 -> Adafruit Watchdog Library Demo!
13:05:00.892 -> 
13:05:00.892 -> Enabled the watchdog with max countdown of 4000 milliseconds!
13:05:00.892 -> 
13:05:00.892 -> Looping ten times while resetting the watchdog...
13:05:00.892 -> Loop #1
13:05:01.888 -> Loop #2
13:05:02.908 -> Loop #3
13:05:03.889 -> Loop #4
13:05:04.912 -> Loop #5
13:05:05.912 -> Loop #6
13:05:06.887 -> Loop #7
13:05:07.878 -> Loop #8
13:05:08.900 -> Loop #9
13:05:09.881 -> Loop #10
13:05:10.901 -> 
13:05:10.901 -> Get ready, the watchdog will reset in 4000 milliseconds!
13:05:10.901 -> 
13:05:14.903 -> E (28625) task_wdt: Task watchdog got triggered. The following tasks/users did not reset the watchdog in time:
13:05:14.903 -> E (28625) task_wdt:  - loopTask (CPU 1)
13:05:14.903 -> E (28625) task_wdt: Tasks currently running:
13:05:14.903 -> E (28625) task_wdt: CPU 0: IDLE
13:05:14.903 -> E (28625) task_wdt: CPU 1: IDLE
13:05:14.941 -> E (28625) task_wdt: Aborting.
13:05:14.941 -> E (28625) task_wdt: Print CPU 1 backtrace
13:05:14.941 -> 
13:05:14.941 -> 
13:05:14.941 -> 
13:05:14.941 -> 
13:05:14.941 -> Backtrace: 0x40087d0b:0x3ffbca50 0x400dab12:0x3ffbca70 0x4008a3c4:0x3ffbca90
13:05:14.941 -> 
13:05:14.941 -> 
13:05:14.941 -> 
13:05:14.941 -> 
13:05:14.941 -> ELF file SHA256: 4e7c25aaa2e0dee8
13:05:14.941 -> 
13:05:14.941 -> Rebooting...
13:05:14.941 -> ets Jul 29 2019 12:21:46
13:05:14.941 -> 
13:05:14.941 -> rst:0xc (SW_CPU_RESET),boot:0x13 (SPI_FAST_FLASH_BOOT)
13:05:14.941 -> configsip: 271414342, SPIWP:0xee
13:05:14.941 -> clk_drv:0x00,q_drv:0x00,d_drv:0x00,cs0_drv:0x00,hd_drv:0x00,wp_drv:0x00
13:05:14.941 -> mode:DIO, clock div:1
13:05:14.976 -> load:0x3fff0030,len:1256
13:05:14.976 -> load:0x40078000,len:13832
13:05:14.976 -> load:0x40080400,len:4
13:05:14.976 -> load:0x40080404,len:3048
13:05:14.976 -> entry 0x40080590
13:05:15.342 -> Adafruit Watchdog Library Demo!

```