### PR TITLE
Bug: The Watchdog example fails to compile on nRF52840

### DIFF
--- a/examples/BasicUsage/BasicUsage.ino
+++ b/examples/BasicUsage/BasicUsage.ino
@@ -41,7 +41,7 @@ void setup() {
   Serial.println();
 
 // can not disable NRF or RP2040 wdt once enabled
-#if !defined(NRF52_SERIES) || !defined(ARDUINO_ARCH_RP2040)
+#if !defined(NRF52_SERIES) && !defined(ARDUINO_ARCH_RP2040)
   // Disable the watchdog entirely by calling Watchdog.disable();
   Watchdog.disable();
 #endif


### PR DESCRIPTION
- Arduino board:  **Adafruit Feather nRF52840 Express**
- Arduino IDE version:  **2.3.4**

# Repro
1. Connect board to Arduino IDE and set it as the target
2. Verify the sketch
3. Error message appears

```
BasicUsage.ino:46:19: error: call to 'WatchdogNRF::disable' declared with attribute error: nRF's WDT cannot be disabled once enabled
   46 |   Watchdog.disable();
      |   ~~~~~~~~~~~~~~~~^~

exit status 1

Compilation error: call to 'WatchdogNRF::disable' declared with attribute error: nRF's WDT cannot be disabled once enabled
```

# Proposed solution
Replace line 44 with `#if !defined(NRF52_SERIES) && !defined(ARDUINO_ARCH_RP2040)` - I think a DeMorgan's law accident occurred here.

I'm having other compilation issues but at least this one has a trivial fix.