### PR TITLE
Update WatchdogNRF.cpp use 64 bit math in reload value calc

### DIFF
--- a/utility/WatchdogNRF.cpp
+++ b/utility/WatchdogNRF.cpp
@@ -17,7 +17,7 @@ int WatchdogNRF::enable(int maxPeriodMS) {
 
   // WDT run when CPU is sleep
   nrf_wdt_behaviour_set(NRF_WDT, NRF_WDT_BEHAVIOUR_RUN_SLEEP);
-  nrf_wdt_reload_value_set(NRF_WDT, (maxPeriodMS * 32768) / 1000);
+  nrf_wdt_reload_value_set(NRF_WDT, ((int64_t)maxPeriodMS * 32768) / 1000);
 
   // use channel 0
   nrf_wdt_reload_request_enable(NRF_WDT, NRF_WDT_RR0);


### PR DESCRIPTION
The nature of the NRF watch dog requires a multiply by 32768 to calculate the reload register value. If using a longer timeout like 300000 ms (5 minutes) it will overflow and not work as intended. This temporarily converts the multiply & divide to a 64 bit operation before setting the register. So longer a timeout can be calculated correctly.

