### PR TITLE
Fix: Regression on ESP32

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit SleepyDog Library
-version=1.8.0
+version=1.8.1
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino library to use the watchdog timer for system reset and low power sleep.

--- a/utility/WatchdogESP32.cpp
+++ b/utility/WatchdogESP32.cpp
@@ -21,7 +21,7 @@ int WatchdogESP32::enable(int maxPeriodMS) {
 #include "soc/soc_caps.h"
   esp_task_wdt_config_t wdt_config = {
       .timeout_ms = (uint32_t)maxPeriodMS,
-      .idle_core_mask = (1 << SOC_CPU_CORES_NUM) - 1, // Bitmask of all cores
+      .idle_core_mask = 0, // Subscribe to the idle task on the APP CPU
       .trigger_panic = true,
   };
   esp_err_t err = esp_task_wdt_init(&wdt_config);


### PR DESCRIPTION
In tag 1.6.6, the `esp_task_wdt_config_t` was changed to match an ESP-IDF example: `idle_core_mask = (1 << SOC_CPU_CORES_NUM) - 1`

While the ESP32-S2 and ESP32-Cx are single-core, for dual core chips like ESP32/ESP32-S3, this subscribes the WDT to all tasks across both cores instead of subscribing only to the Arduino App Loop Task (which is on core 1).

As a result on ESP32-S3, Core 1 is fed but Core 2 is starved and causes a WDT reset if regardless the WDT is fed.

This PR reverts the `idle_core_mask` subscription back to the prior behavior, subscribing only to the Arduino App Loop Task  Core