### PR TITLE
Add Windows USB re-enumeration fix for SleepRP2350Timer with USB unplug note after upload

### DIFF
--- a/examples/SleepRP2350Pin/SleepRP2350Pin.ino
+++ b/examples/SleepRP2350Pin/SleepRP2350Pin.ino
@@ -5,12 +5,19 @@
 //
 // Brent Rubell for Adafruit Industries
 //
+// NOTE: After uploading, physically unplug and replug the USB cable to
+// reset the AON timer correctly before running.
 
 #include <Adafruit_SleepyDog.h>
+#ifdef USE_TINYUSB
+#include <Adafruit_TinyUSB.h>
+#else
+#include "USB.h"
+#endif
 #define WAKE_PIN 2 // GPIO pin to wake on, change as needed for your use case
 
 void setup() {
-  pinMode(LED_BUILTIN, OUTPUT);
+    pinMode(LED_BUILTIN, OUTPUT);
   digitalWrite(LED_BUILTIN, HIGH);
 
   Serial.begin(115200);
@@ -20,7 +27,7 @@ void setup() {
 }
 
 void loop() {
-  Serial.println("Going to sleep in 5 seconds...");
+    Serial.println("Going to sleep in 5 seconds...");
   Serial.println("To wake up, connect GPIO pin 2 to 3.3V (for HIGH wake).");
   delay(5000);
 
@@ -42,6 +49,16 @@ void loop() {
   // Re-enable clocks, generators, USB and resume execution
   // NOTE: This MUST be called to properly resume from sleep!
   Watchdog.resumeFromSleep();
+  #ifndef USE_TINYUSB
+  // Re-enable USB after sleep. Required for Windows where USB
+  // does not re-enumerate automatically. On macOS and Linux, USB is
+  // maintained across sleep cycles. If you use an external serial terminal
+  // (e.g. screen, minicom), comment out USB.disconnect() and USB.connect()
+  // to prevent the port from disconnecting on each wake cycle.
+  USB.disconnect();
+  delay(500); // Give host time to register disconnect before reconnecting
+  USB.connect();
+  #endif
 
   // NOTE: We can not track sleep duration when waking from a pin because we use
   // the crystal oscillator as the dormant clock source, so the AON timer we'd

--- a/examples/SleepRP2350Pin/SleepRP2350Pin.ino
+++ b/examples/SleepRP2350Pin/SleepRP2350Pin.ino
@@ -17,7 +17,7 @@
 #define WAKE_PIN 2 // GPIO pin to wake on, change as needed for your use case
 
 void setup() {
-    pinMode(LED_BUILTIN, OUTPUT);
+  pinMode(LED_BUILTIN, OUTPUT);
   digitalWrite(LED_BUILTIN, HIGH);
 
   Serial.begin(115200);
@@ -27,7 +27,7 @@ void setup() {
 }
 
 void loop() {
-    Serial.println("Going to sleep in 5 seconds...");
+  Serial.println("Going to sleep in 5 seconds...");
   Serial.println("To wake up, connect GPIO pin 2 to 3.3V (for HIGH wake).");
   delay(5000);
 

--- a/examples/SleepRP2350Timer/SleepRP2350Timer.ino
+++ b/examples/SleepRP2350Timer/SleepRP2350Timer.ino
@@ -11,7 +11,11 @@
 // reset the AON timer correctly before running.
 
 #include <Adafruit_SleepyDog.h>
+#ifdef USE_TINYUSB
+#include <Adafruit_TinyUSB.h>
+#else
 #include "USB.h"
+#endif
 
 static bool awake;
 
@@ -58,7 +62,8 @@ void loop() {
   // Re-enable clocks, generators, USB and resume execution
   // NOTE: This MUST be called to properly resume from sleep!
   Watchdog.resumeFromSleep();
-        // Re-enable USB and Serial after sleep. Required for Windows where USB
+        #ifndef USE_TINYUSB
+  // Re-enable USB and Serial after sleep. Required for Windows where USB
     // does not re-enumerate automatically. On macOS and Linux, USB is
     // maintained across sleep cycles. If you use an external serial terminal
     // (e.g. screen, minicom), comment out USB.disconnect() and USB.connect()
@@ -67,6 +72,7 @@ void loop() {
     USB.connect();
     Serial.begin(115200);
     while (!Serial);
+  #endif
 
   Serial.println("I'm awake now!");
   Serial.print("Slept for approximately ");

--- a/examples/SleepRP2350Timer/SleepRP2350Timer.ino
+++ b/examples/SleepRP2350Timer/SleepRP2350Timer.ino
@@ -58,7 +58,7 @@ void loop() {
   // Re-enable clocks, generators, USB and resume execution
   // NOTE: This MUST be called to properly resume from sleep!
   Watchdog.resumeFromSleep();
-    // Re-enable USB and Serial for Windows/Linux compatibility
+      // Re-enable USB and Serial (required for Windows USB re-enumeration after sleep)
     USB.disconnect();
     USB.connect();
     Serial.begin(115200);

--- a/examples/SleepRP2350Timer/SleepRP2350Timer.ino
+++ b/examples/SleepRP2350Timer/SleepRP2350Timer.ino
@@ -58,7 +58,11 @@ void loop() {
   // Re-enable clocks, generators, USB and resume execution
   // NOTE: This MUST be called to properly resume from sleep!
   Watchdog.resumeFromSleep();
-      // Re-enable USB and Serial (required for Windows USB re-enumeration after sleep)
+        // Re-enable USB and Serial after sleep. Required for Windows where USB
+    // does not re-enumerate automatically. On macOS and Linux, USB is
+    // maintained across sleep cycles. If you use an external serial terminal
+    // (e.g. screen, minicom), comment out USB.disconnect() and USB.connect()
+    // to prevent the port from disconnecting on each wake cycle.
     USB.disconnect();
     USB.connect();
     Serial.begin(115200);

--- a/examples/SleepRP2350Timer/SleepRP2350Timer.ino
+++ b/examples/SleepRP2350Timer/SleepRP2350Timer.ino
@@ -69,6 +69,7 @@ void loop() {
     // (e.g. screen, minicom), comment out USB.disconnect() and USB.connect()
     // to prevent the port from disconnecting on each wake cycle.
     USB.disconnect();
+      delay(500); // Give host time to register disconnect before reconnecting
     USB.connect();
   #endif
 

--- a/examples/SleepRP2350Timer/SleepRP2350Timer.ino
+++ b/examples/SleepRP2350Timer/SleepRP2350Timer.ino
@@ -7,6 +7,8 @@
 //
 // Brent Rubell for Adafruit Industries
 //
+// NOTE: After uploading, physically unplug and replug the USB cable to
+// reset the AON timer correctly before running.
 
 #include <Adafruit_SleepyDog.h>
 

--- a/examples/SleepRP2350Timer/SleepRP2350Timer.ino
+++ b/examples/SleepRP2350Timer/SleepRP2350Timer.ino
@@ -63,15 +63,13 @@ void loop() {
   // NOTE: This MUST be called to properly resume from sleep!
   Watchdog.resumeFromSleep();
         #ifndef USE_TINYUSB
-  // Re-enable USB and Serial after sleep. Required for Windows where USB
+      // Re-enable USB after sleep. Required for Windows where USB
     // does not re-enumerate automatically. On macOS and Linux, USB is
     // maintained across sleep cycles. If you use an external serial terminal
     // (e.g. screen, minicom), comment out USB.disconnect() and USB.connect()
     // to prevent the port from disconnecting on each wake cycle.
     USB.disconnect();
     USB.connect();
-    Serial.begin(115200);
-    while (!Serial);
   #endif
 
   Serial.println("I'm awake now!");

--- a/examples/SleepRP2350Timer/SleepRP2350Timer.ino
+++ b/examples/SleepRP2350Timer/SleepRP2350Timer.ino
@@ -11,6 +11,7 @@
 // reset the AON timer correctly before running.
 
 #include <Adafruit_SleepyDog.h>
+#include "USB.h"
 
 static bool awake;
 
@@ -57,6 +58,11 @@ void loop() {
   // Re-enable clocks, generators, USB and resume execution
   // NOTE: This MUST be called to properly resume from sleep!
   Watchdog.resumeFromSleep();
+    // Re-enable USB and Serial for Windows/Linux compatibility
+    USB.disconnect();
+    USB.connect();
+    Serial.begin(115200);
+    while (!Serial);
 
   Serial.println("I'm awake now!");
   Serial.print("Slept for approximately ");


### PR DESCRIPTION
Added USB.connect/disconnect for windows re-enumeration.Also a header comment to SleepRP2350Timer.ino noting that after uploading, the user must physically unplug and replug the USB cable to reset the AON timer correctly before the example will run as expected.

Suggested by:

-  [palmerr23 in the Adafruit forums](https://forums.adafruit.com/viewtopic.php?t=223127) 
- Earle Phil Hower from [Feature Request: support deep sleep for the RP2350 · Issue #2528](https://github.com/earlephilhower/arduino-pico/issues/2528)