### PR TITLE
Add Raspberry Pi platform tests to CI workflow

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -20,8 +20,19 @@ jobs:
     - name: pre-install
       run: bash ci/actions_install.sh
 
+    - name: check arduino-cli location + version
+      run: |
+        echo "Arduino CLI location:"
+        which arduino-cli
+        echo "Arduino CLI version (and path check):"
+        arduino-cli version
+        echo "Is on PATH?"
+        echo $PATH
+        echo "Config dump / file location:"
+        arduino-cli config dump --verbose
+
     - name: test WS platforms
-      run: python3 ci/build_platform.py wippersnapper_platforms
+      run: python3 ci/build_platform.py feather_rp2040
 
     - name: test platforms
       run: python3 ci/build_platform.py main_platforms

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -41,24 +41,20 @@ jobs:
         echo "running from $(pwd)"
         echo "arduino-cli available at: $(which arduino-cli)"
         python3 ci/build_platform.py rp2040_platforms
+        # avoid uninstall
+        rm -f ~/Arduino/libraries/Adafruit_SleepyDog
+        cd "$GITHUB_WORKSPACE"
+        echo "running from $(pwd)"
         # python3 ci/build_platform.py feather_rp2040
         # python3 ci/build_platform.py pico_rp2040
-        cd "$GITHUB_WORKSPACE"   # <-- add this
         python3 ci/build_platform.py pico_rp2040_tinyusb
-        cd "$GITHUB_WORKSPACE"   # <-- add this
         python3 ci/build_platform.py pico_rp2040_tinyusb_host
-        cd "$GITHUB_WORKSPACE"   # <-- add this
         # python3 ci/build_platform.py feather_rp2350
         python3 ci/build_platform.py pico_rp2350
-        cd "$GITHUB_WORKSPACE"   # <-- add this
         python3 ci/build_platform.py pico_rp2350_tinyusb
-        cd "$GITHUB_WORKSPACE"   # <-- add this
         python3 ci/build_platform.py pico_rp2350_tinyusb_host
-        cd "$GITHUB_WORKSPACE"   # <-- add this
         python3 ci/build_platform.py picow_rp2040
-        cd "$GITHUB_WORKSPACE"   # <-- add this
         python3 ci/build_platform.py picow_rp2040_tinyusb
-        cd "$GITHUB_WORKSPACE"   # <-- add this
         python3 ci/build_platform.py main_platforms
 
     - name: clang

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -43,14 +43,22 @@ jobs:
         python3 ci/build_platform.py rp2040_platforms
         # python3 ci/build_platform.py feather_rp2040
         # python3 ci/build_platform.py pico_rp2040
+        cd "$GITHUB_WORKSPACE"   # <-- add this
         python3 ci/build_platform.py pico_rp2040_tinyusb
+        cd "$GITHUB_WORKSPACE"   # <-- add this
         python3 ci/build_platform.py pico_rp2040_tinyusb_host
+        cd "$GITHUB_WORKSPACE"   # <-- add this
         # python3 ci/build_platform.py feather_rp2350
         python3 ci/build_platform.py pico_rp2350
+        cd "$GITHUB_WORKSPACE"   # <-- add this
         python3 ci/build_platform.py pico_rp2350_tinyusb
+        cd "$GITHUB_WORKSPACE"   # <-- add this
         python3 ci/build_platform.py pico_rp2350_tinyusb_host
+        cd "$GITHUB_WORKSPACE"   # <-- add this
         python3 ci/build_platform.py picow_rp2040
+        cd "$GITHUB_WORKSPACE"   # <-- add this
         python3 ci/build_platform.py picow_rp2040_tinyusb
+        cd "$GITHUB_WORKSPACE"   # <-- add this
         python3 ci/build_platform.py main_platforms
 
     - name: clang

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -33,12 +33,14 @@ jobs:
         echo "Config dump / file location:"
         arduino-cli config dump --verbose
 
+    - name: Move arduino-cli to /usr/local/bin
+      run: sudo mv $(which arduino-cli) /usr/local/bin/arduino-cli
+
     - name: test WS platforms
       run: |
         echo "running from $(pwd)"
         echo "arduino-cli available at: $(which arduino-cli)"
         python3 ci/build_platform.py feather_rp2040
-
 
     - name: test platforms
       run: |
@@ -50,7 +52,6 @@ jobs:
       run: |
         echo "running from $(pwd)"
         echo "arduino-cli available at: $(which arduino-cli)"
-        echo "running from $(pwd)"
         python3 ci/build_platform.py rp2040_platforms
         python3 ci/build_platform.py pico_rp2040
         python3 ci/build_platform.py pico_rp2040_tinyusb

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -22,6 +22,8 @@ jobs:
 
     - name: check arduino-cli location + version
       run: |
+        echo "CWD:"
+        pwd
         echo "Arduino CLI location:"
         which arduino-cli
         echo "Arduino CLI version (and path check):"
@@ -32,13 +34,23 @@ jobs:
         arduino-cli config dump --verbose
 
     - name: test WS platforms
-      run: python3 ci/build_platform.py feather_rp2040
+      run: |
+        echo "running from $(pwd)"
+        echo "arduino-cli available at: $(which arduino-cli)"
+        python3 ci/build_platform.py feather_rp2040
+
 
     - name: test platforms
-      run: python3 ci/build_platform.py main_platforms
+      run: |
+        echo "running from $(pwd)"
+        echo "arduino-cli available at: $(which arduino-cli)"
+        python3 ci/build_platform.py main_platforms
 
     - name: test Raspberry Pi platforms
       run: |
+        echo "running from $(pwd)"
+        echo "arduino-cli available at: $(which arduino-cli)"
+        echo "running from $(pwd)"
         python3 ci/build_platform.py rp2040_platforms
         python3 ci/build_platform.py pico_rp2040
         python3 ci/build_platform.py pico_rp2040_tinyusb

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -22,6 +22,20 @@ jobs:
     - name: test platforms
       run: python3 ci/build_platform.py main_platforms
 
+    - name: test Raspberry Pi platforms
+      run: | 
+        python3 ci/build_platform.py rp2040_platforms
+        python3 ci/build_platform.py pico_rp2040
+        python3 ci/build_platform.py pico_rp2040_tinyusb
+        python3 ci/build_platform.py pico_rp2040_tinyusb_host
+        python3 ci/build_platform.py pico_rp2350
+        python3 ci/build_platform.py pico_rp2350_tinyusb
+        python3 ci/build_platform.py pico_rp2350_tinyusb_host
+        python3 ci/build_platform.py picow_rp2040
+        python3 ci/build_platform.py picow_rp2040_tinyusb
+        # Ideally check wippersnapper_platforms, but from
+        # ci-arduino/all_platforms.py at ci-wippersnapper
+
     - name: clang
       run: python3 ci/run-clang-format.py -e "ci/*" -e "bin/*" -r . 
 

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -15,15 +15,19 @@ jobs:
       with:
          repository: adafruit/ci-arduino
          path: ci
+         ref: ci-wippersnapper
 
     - name: pre-install
       run: bash ci/actions_install.sh
+
+    - name: test WS platforms
+      run: python3 ci/build_platform.py wippersnapper_platforms
 
     - name: test platforms
       run: python3 ci/build_platform.py main_platforms
 
     - name: test Raspberry Pi platforms
-      run: | 
+      run: |
         python3 ci/build_platform.py rp2040_platforms
         python3 ci/build_platform.py pico_rp2040
         python3 ci/build_platform.py pico_rp2040_tinyusb

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -41,21 +41,10 @@ jobs:
         echo "running from $(pwd)"
         echo "arduino-cli available at: $(which arduino-cli)"
         python3 ci/build_platform.py rp2040_platforms
-        # avoid uninstall
-        rm -f ~/Arduino/libraries/Adafruit_SleepyDog
-        cd "$GITHUB_WORKSPACE"
-        echo "running from $(pwd)"
-        # python3 ci/build_platform.py feather_rp2040
-        # python3 ci/build_platform.py pico_rp2040
-        python3 ci/build_platform.py pico_rp2040_tinyusb
-        python3 ci/build_platform.py pico_rp2040_tinyusb_host
-        # python3 ci/build_platform.py feather_rp2350
-        python3 ci/build_platform.py pico_rp2350
-        python3 ci/build_platform.py pico_rp2350_tinyusb
-        python3 ci/build_platform.py pico_rp2350_tinyusb_host
-        python3 ci/build_platform.py picow_rp2040
-        python3 ci/build_platform.py picow_rp2040_tinyusb
-        python3 ci/build_platform.py main_platforms
+        for platform in pico_rp2040_tinyusb pico_rp2040_tinyusb_host pico_rp2350 pico_rp2350_tinyusb pico_rp2350_tinyusb_host picow_rp2040 picow_rp2040_tinyusb main_platforms; do
+          rm -f ~/Arduino/libraries/Adafruit_SleepyDog
+          python3 ci/build_platform.py $platform
+        done
 
     - name: clang
       run: python3 ci/run-clang-format.py -e "ci/*" -e "bin/*" -r . 

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -36,33 +36,22 @@ jobs:
     - name: Move arduino-cli to /usr/local/bin
       run: sudo mv $(which arduino-cli) /usr/local/bin/arduino-cli
 
-    - name: test WS platforms
-      run: |
-        echo "running from $(pwd)"
-        echo "arduino-cli available at: $(which arduino-cli)"
-        python3 ci/build_platform.py feather_rp2040
-
     - name: test platforms
       run: |
         echo "running from $(pwd)"
         echo "arduino-cli available at: $(which arduino-cli)"
-        python3 ci/build_platform.py main_platforms
-
-    - name: test Raspberry Pi platforms
-      run: |
-        echo "running from $(pwd)"
-        echo "arduino-cli available at: $(which arduino-cli)"
         python3 ci/build_platform.py rp2040_platforms
-        python3 ci/build_platform.py pico_rp2040
+        # python3 ci/build_platform.py feather_rp2040
+        # python3 ci/build_platform.py pico_rp2040
         python3 ci/build_platform.py pico_rp2040_tinyusb
         python3 ci/build_platform.py pico_rp2040_tinyusb_host
+        # python3 ci/build_platform.py feather_rp2350
         python3 ci/build_platform.py pico_rp2350
         python3 ci/build_platform.py pico_rp2350_tinyusb
         python3 ci/build_platform.py pico_rp2350_tinyusb_host
         python3 ci/build_platform.py picow_rp2040
         python3 ci/build_platform.py picow_rp2040_tinyusb
-        # Ideally check wippersnapper_platforms, but from
-        # ci-arduino/all_platforms.py at ci-wippersnapper
+        python3 ci/build_platform.py main_platforms
 
     - name: clang
       run: python3 ci/run-clang-format.py -e "ci/*" -e "bin/*" -r . 

--- a/examples/BasicUsage/BasicUsage.ino
+++ b/examples/BasicUsage/BasicUsage.ino
@@ -41,7 +41,7 @@ void setup() {
   Serial.println();
 
 // can not disable NRF or RP2040 wdt once enabled
-#if !defined(NRF52_SERIES) || !defined(ARDUINO_ARCH_RP2040)
+#if !defined(NRF52_SERIES) && !defined(ARDUINO_ARCH_RP2040)
   // Disable the watchdog entirely by calling Watchdog.disable();
   Watchdog.disable();
 #endif


### PR DESCRIPTION
Added a step to test various Raspberry Pi platforms in the CI workflow, to give more confidence when making changes.
Likely to fail as I've included all the rp2 targets in various usb modes.

Fixes BasicUsage example to not call Watchdog.disable for rp2040 (conditional was !def(NRF) || !def(RP2), now &&)


Currently the CI test list is limited to main_platforms:

https://github.com/adafruit/ci-arduino/blob/98013dfdfce85b074df37822736861472e2f4495/all_platforms.py#L173-L174