### PR TITLE
fix(ci): rm symlink before each build_platform.py call to avoid getcwd error

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -41,21 +41,10 @@ jobs:
         echo "running from $(pwd)"
         echo "arduino-cli available at: $(which arduino-cli)"
         python3 ci/build_platform.py rp2040_platforms
-        # avoid uninstall
-        rm -f ~/Arduino/libraries/Adafruit_SleepyDog
-        cd "$GITHUB_WORKSPACE"
-        echo "running from $(pwd)"
-        # python3 ci/build_platform.py feather_rp2040
-        # python3 ci/build_platform.py pico_rp2040
-        python3 ci/build_platform.py pico_rp2040_tinyusb
-        python3 ci/build_platform.py pico_rp2040_tinyusb_host
-        # python3 ci/build_platform.py feather_rp2350
-        python3 ci/build_platform.py pico_rp2350
-        python3 ci/build_platform.py pico_rp2350_tinyusb
-        python3 ci/build_platform.py pico_rp2350_tinyusb_host
-        python3 ci/build_platform.py picow_rp2040
-        python3 ci/build_platform.py picow_rp2040_tinyusb
-        python3 ci/build_platform.py main_platforms
+        for platform in pico_rp2040_tinyusb pico_rp2040_tinyusb_host pico_rp2350 pico_rp2350_tinyusb pico_rp2350_tinyusb_host picow_rp2040 picow_rp2040_tinyusb main_platforms; do
+          rm -f ~/Arduino/libraries/Adafruit_SleepyDog
+          python3 ci/build_platform.py $platform
+        done
 
     - name: clang
       run: python3 ci/run-clang-format.py -e "ci/*" -e "bin/*" -r . 


### PR DESCRIPTION
## Problem

Each call to `python3 ci/build_platform.py <platform>` runs `arduino-cli lib uninstall` inside `install_library_deps()`, which follows the symlink at `~/Arduino/libraries/Adafruit_SleepyDog` → repo checkout and deletes it. This leaves the shell's cwd pointing at a deleted directory, causing:

```
sh: 0: getcwd() failed: No such file or directory
FileNotFoundError: No such file or directory: '.../examples'
```

The previous fix added a single `rm -f` before the second call, but with 8+ sequential `build_platform.py` calls, each one recreates and then destroys the symlink.

## Fix

Use a loop that removes the stale symlink before every `build_platform.py` call after the first. Also removes the now-unnecessary commented-out lines and redundant `cd`.