### PR TITLE
test: combined PR65+PR66 using ci-arduino --skip-uninstall flag

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -20,8 +20,19 @@ jobs:
     - name: pre-install
       run: bash ci/actions_install.sh
 
+    - name: check arduino-cli location + version
+      run: |
+        echo "Arduino CLI location:"
+        which arduino-cli
+        echo "Arduino CLI version (and path check):"
+        arduino-cli version
+        echo "Is on PATH?"
+        echo $PATH
+        echo "Config dump / file location:"
+        arduino-cli config dump --verbose
+
     - name: test WS platforms
-      run: python3 ci/build_platform.py wippersnapper_platforms
+      run: python3 ci/build_platform.py feather_rp2040
 
     - name: test platforms
       run: python3 ci/build_platform.py main_platforms

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -13,9 +13,9 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/checkout@v3
       with:
-         repository: adafruit/ci-arduino
+         repository: tyeth-ai-assisted/ci-arduino
          path: ci
-         ref: ci-wippersnapper
+         ref: feature/skip-uninstall
 
     - name: pre-install
       run: bash ci/actions_install.sh
@@ -42,8 +42,7 @@ jobs:
         echo "arduino-cli available at: $(which arduino-cli)"
         python3 ci/build_platform.py rp2040_platforms
         for platform in pico_rp2040_tinyusb pico_rp2040_tinyusb_host pico_rp2350 pico_rp2350_tinyusb pico_rp2350_tinyusb_host picow_rp2040 picow_rp2040_tinyusb main_platforms; do
-          rm -f ~/Arduino/libraries/Adafruit_SleepyDog
-          python3 ci/build_platform.py $platform
+          python3 ci/build_platform.py $platform --skip-uninstall
         done
 
     - name: clang

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -41,24 +41,20 @@ jobs:
         echo "running from $(pwd)"
         echo "arduino-cli available at: $(which arduino-cli)"
         python3 ci/build_platform.py rp2040_platforms
+        # avoid uninstall
+        rm -f ~/Arduino/libraries/Adafruit_SleepyDog
+        cd "$GITHUB_WORKSPACE"
+        echo "running from $(pwd)"
         # python3 ci/build_platform.py feather_rp2040
         # python3 ci/build_platform.py pico_rp2040
-        cd "$GITHUB_WORKSPACE"   # <-- add this
         python3 ci/build_platform.py pico_rp2040_tinyusb
-        cd "$GITHUB_WORKSPACE"   # <-- add this
         python3 ci/build_platform.py pico_rp2040_tinyusb_host
-        cd "$GITHUB_WORKSPACE"   # <-- add this
         # python3 ci/build_platform.py feather_rp2350
         python3 ci/build_platform.py pico_rp2350
-        cd "$GITHUB_WORKSPACE"   # <-- add this
         python3 ci/build_platform.py pico_rp2350_tinyusb
-        cd "$GITHUB_WORKSPACE"   # <-- add this
         python3 ci/build_platform.py pico_rp2350_tinyusb_host
-        cd "$GITHUB_WORKSPACE"   # <-- add this
         python3 ci/build_platform.py picow_rp2040
-        cd "$GITHUB_WORKSPACE"   # <-- add this
         python3 ci/build_platform.py picow_rp2040_tinyusb
-        cd "$GITHUB_WORKSPACE"   # <-- add this
         python3 ci/build_platform.py main_platforms
 
     - name: clang

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -43,14 +43,22 @@ jobs:
         python3 ci/build_platform.py rp2040_platforms
         # python3 ci/build_platform.py feather_rp2040
         # python3 ci/build_platform.py pico_rp2040
+        cd "$GITHUB_WORKSPACE"   # <-- add this
         python3 ci/build_platform.py pico_rp2040_tinyusb
+        cd "$GITHUB_WORKSPACE"   # <-- add this
         python3 ci/build_platform.py pico_rp2040_tinyusb_host
+        cd "$GITHUB_WORKSPACE"   # <-- add this
         # python3 ci/build_platform.py feather_rp2350
         python3 ci/build_platform.py pico_rp2350
+        cd "$GITHUB_WORKSPACE"   # <-- add this
         python3 ci/build_platform.py pico_rp2350_tinyusb
+        cd "$GITHUB_WORKSPACE"   # <-- add this
         python3 ci/build_platform.py pico_rp2350_tinyusb_host
+        cd "$GITHUB_WORKSPACE"   # <-- add this
         python3 ci/build_platform.py picow_rp2040
+        cd "$GITHUB_WORKSPACE"   # <-- add this
         python3 ci/build_platform.py picow_rp2040_tinyusb
+        cd "$GITHUB_WORKSPACE"   # <-- add this
         python3 ci/build_platform.py main_platforms
 
     - name: clang

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -33,12 +33,14 @@ jobs:
         echo "Config dump / file location:"
         arduino-cli config dump --verbose
 
+    - name: Move arduino-cli to /usr/local/bin
+      run: sudo mv $(which arduino-cli) /usr/local/bin/arduino-cli
+
     - name: test WS platforms
       run: |
         echo "running from $(pwd)"
         echo "arduino-cli available at: $(which arduino-cli)"
         python3 ci/build_platform.py feather_rp2040
-
 
     - name: test platforms
       run: |
@@ -50,7 +52,6 @@ jobs:
       run: |
         echo "running from $(pwd)"
         echo "arduino-cli available at: $(which arduino-cli)"
-        echo "running from $(pwd)"
         python3 ci/build_platform.py rp2040_platforms
         python3 ci/build_platform.py pico_rp2040
         python3 ci/build_platform.py pico_rp2040_tinyusb

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -22,6 +22,8 @@ jobs:
 
     - name: check arduino-cli location + version
       run: |
+        echo "CWD:"
+        pwd
         echo "Arduino CLI location:"
         which arduino-cli
         echo "Arduino CLI version (and path check):"
@@ -32,13 +34,23 @@ jobs:
         arduino-cli config dump --verbose
 
     - name: test WS platforms
-      run: python3 ci/build_platform.py feather_rp2040
+      run: |
+        echo "running from $(pwd)"
+        echo "arduino-cli available at: $(which arduino-cli)"
+        python3 ci/build_platform.py feather_rp2040
+
 
     - name: test platforms
-      run: python3 ci/build_platform.py main_platforms
+      run: |
+        echo "running from $(pwd)"
+        echo "arduino-cli available at: $(which arduino-cli)"
+        python3 ci/build_platform.py main_platforms
 
     - name: test Raspberry Pi platforms
       run: |
+        echo "running from $(pwd)"
+        echo "arduino-cli available at: $(which arduino-cli)"
+        echo "running from $(pwd)"
         python3 ci/build_platform.py rp2040_platforms
         python3 ci/build_platform.py pico_rp2040
         python3 ci/build_platform.py pico_rp2040_tinyusb

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -45,7 +45,7 @@ jobs:
         echo "running from $(pwd)"
         echo "arduino-cli available at: $(which arduino-cli)"
         python3 ci/build_platform.py rp2040_platforms
-        for platform in pico_rp2350 picow_rp2040 main_platforms; do
+        for platform in pico_rp2040_tinyusb pico_rp2040_tinyusb_host pico_rp2350 pico_rp2350_tinyusb pico_rp2350_tinyusb_host picow_rp2040 picow_rp2040_tinyusb main_platforms; do
           python3 ci/build_platform.py $platform --skip-uninstall
         done
 

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -22,6 +22,20 @@ jobs:
     - name: test platforms
       run: python3 ci/build_platform.py main_platforms
 
+    - name: test Raspberry Pi platforms
+      run: | 
+        python3 ci/build_platform.py rp2040_platforms
+        python3 ci/build_platform.py pico_rp2040
+        python3 ci/build_platform.py pico_rp2040_tinyusb
+        python3 ci/build_platform.py pico_rp2040_tinyusb_host
+        python3 ci/build_platform.py pico_rp2350
+        python3 ci/build_platform.py pico_rp2350_tinyusb
+        python3 ci/build_platform.py pico_rp2350_tinyusb_host
+        python3 ci/build_platform.py picow_rp2040
+        python3 ci/build_platform.py picow_rp2040_tinyusb
+        # Ideally check wippersnapper_platforms, but from
+        # ci-arduino/all_platforms.py at ci-wippersnapper
+
     - name: clang
       run: python3 ci/run-clang-format.py -e "ci/*" -e "bin/*" -r . 
 

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -15,15 +15,19 @@ jobs:
       with:
          repository: adafruit/ci-arduino
          path: ci
+         ref: ci-wippersnapper
 
     - name: pre-install
       run: bash ci/actions_install.sh
+
+    - name: test WS platforms
+      run: python3 ci/build_platform.py wippersnapper_platforms
 
     - name: test platforms
       run: python3 ci/build_platform.py main_platforms
 
     - name: test Raspberry Pi platforms
-      run: | 
+      run: |
         python3 ci/build_platform.py rp2040_platforms
         python3 ci/build_platform.py pico_rp2040
         python3 ci/build_platform.py pico_rp2040_tinyusb

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -41,21 +41,10 @@ jobs:
         echo "running from $(pwd)"
         echo "arduino-cli available at: $(which arduino-cli)"
         python3 ci/build_platform.py rp2040_platforms
-        # avoid uninstall
-        rm -f ~/Arduino/libraries/Adafruit_SleepyDog
-        cd "$GITHUB_WORKSPACE"
-        echo "running from $(pwd)"
-        # python3 ci/build_platform.py feather_rp2040
-        # python3 ci/build_platform.py pico_rp2040
-        python3 ci/build_platform.py pico_rp2040_tinyusb
-        python3 ci/build_platform.py pico_rp2040_tinyusb_host
-        # python3 ci/build_platform.py feather_rp2350
-        python3 ci/build_platform.py pico_rp2350
-        python3 ci/build_platform.py pico_rp2350_tinyusb
-        python3 ci/build_platform.py pico_rp2350_tinyusb_host
-        python3 ci/build_platform.py picow_rp2040
-        python3 ci/build_platform.py picow_rp2040_tinyusb
-        python3 ci/build_platform.py main_platforms
+        for platform in pico_rp2040_tinyusb pico_rp2040_tinyusb_host pico_rp2350 pico_rp2350_tinyusb pico_rp2350_tinyusb_host picow_rp2040 picow_rp2040_tinyusb main_platforms; do
+          rm -f ~/Arduino/libraries/Adafruit_SleepyDog
+          python3 ci/build_platform.py $platform
+        done
 
     - name: clang
       run: python3 ci/run-clang-format.py -e "ci/*" -e "bin/*" -r . 

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -45,7 +45,7 @@ jobs:
         echo "running from $(pwd)"
         echo "arduino-cli available at: $(which arduino-cli)"
         python3 ci/build_platform.py rp2040_platforms
-        for platform in pico_rp2040_tinyusb pico_rp2040_tinyusb_host pico_rp2350 pico_rp2350_tinyusb pico_rp2350_tinyusb_host picow_rp2040 picow_rp2040_tinyusb main_platforms; do
+        for platform in pico_rp2350 picow_rp2040 main_platforms; do
           python3 ci/build_platform.py $platform --skip-uninstall
         done
 

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -20,6 +20,10 @@ jobs:
     - name: pre-install
       run: bash ci/actions_install.sh
 
+    - name: Install extra Arduino libraries
+      run: |
+        git clone --quiet https://github.com/adafruit/Adafruit_TinyUSB_Arduino /home/runner/Arduino/libraries/Adafruit_TinyUSB_Arduino
+
     - name: check arduino-cli location + version
       run: |
         echo "CWD:"

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -36,33 +36,22 @@ jobs:
     - name: Move arduino-cli to /usr/local/bin
       run: sudo mv $(which arduino-cli) /usr/local/bin/arduino-cli
 
-    - name: test WS platforms
-      run: |
-        echo "running from $(pwd)"
-        echo "arduino-cli available at: $(which arduino-cli)"
-        python3 ci/build_platform.py feather_rp2040
-
     - name: test platforms
       run: |
         echo "running from $(pwd)"
         echo "arduino-cli available at: $(which arduino-cli)"
-        python3 ci/build_platform.py main_platforms
-
-    - name: test Raspberry Pi platforms
-      run: |
-        echo "running from $(pwd)"
-        echo "arduino-cli available at: $(which arduino-cli)"
         python3 ci/build_platform.py rp2040_platforms
-        python3 ci/build_platform.py pico_rp2040
+        # python3 ci/build_platform.py feather_rp2040
+        # python3 ci/build_platform.py pico_rp2040
         python3 ci/build_platform.py pico_rp2040_tinyusb
         python3 ci/build_platform.py pico_rp2040_tinyusb_host
+        # python3 ci/build_platform.py feather_rp2350
         python3 ci/build_platform.py pico_rp2350
         python3 ci/build_platform.py pico_rp2350_tinyusb
         python3 ci/build_platform.py pico_rp2350_tinyusb_host
         python3 ci/build_platform.py picow_rp2040
         python3 ci/build_platform.py picow_rp2040_tinyusb
-        # Ideally check wippersnapper_platforms, but from
-        # ci-arduino/all_platforms.py at ci-wippersnapper
+        python3 ci/build_platform.py main_platforms
 
     - name: clang
       run: python3 ci/run-clang-format.py -e "ci/*" -e "bin/*" -r . 

--- a/examples/BasicUsage/BasicUsage.ino
+++ b/examples/BasicUsage/BasicUsage.ino
@@ -41,7 +41,7 @@ void setup() {
   Serial.println();
 
 // can not disable NRF or RP2040 wdt once enabled
-#if !defined(NRF52_SERIES) || !defined(ARDUINO_ARCH_RP2040)
+#if !defined(NRF52_SERIES) && !defined(ARDUINO_ARCH_RP2040)
   // Disable the watchdog entirely by calling Watchdog.disable();
   Watchdog.disable();
 #endif

--- a/examples/SleepRP2350Pin/SleepRP2350Pin.ino
+++ b/examples/SleepRP2350Pin/SleepRP2350Pin.ino
@@ -5,12 +5,19 @@
 //
 // Brent Rubell for Adafruit Industries
 //
+// NOTE: After uploading, physically unplug and replug the USB cable to
+// reset the AON timer correctly before running.
 
 #include <Adafruit_SleepyDog.h>
+#ifdef USE_TINYUSB
+#include <Adafruit_TinyUSB.h>
+#else
+#include "USB.h"
+#endif
 #define WAKE_PIN 2 // GPIO pin to wake on, change as needed for your use case
 
 void setup() {
-  pinMode(LED_BUILTIN, OUTPUT);
+    pinMode(LED_BUILTIN, OUTPUT);
   digitalWrite(LED_BUILTIN, HIGH);
 
   Serial.begin(115200);
@@ -20,7 +27,7 @@ void setup() {
 }
 
 void loop() {
-  Serial.println("Going to sleep in 5 seconds...");
+    Serial.println("Going to sleep in 5 seconds...");
   Serial.println("To wake up, connect GPIO pin 2 to 3.3V (for HIGH wake).");
   delay(5000);
 
@@ -42,6 +49,16 @@ void loop() {
   // Re-enable clocks, generators, USB and resume execution
   // NOTE: This MUST be called to properly resume from sleep!
   Watchdog.resumeFromSleep();
+  #ifndef USE_TINYUSB
+  // Re-enable USB after sleep. Required for Windows where USB
+  // does not re-enumerate automatically. On macOS and Linux, USB is
+  // maintained across sleep cycles. If you use an external serial terminal
+  // (e.g. screen, minicom), comment out USB.disconnect() and USB.connect()
+  // to prevent the port from disconnecting on each wake cycle.
+  USB.disconnect();
+  delay(500); // Give host time to register disconnect before reconnecting
+  USB.connect();
+  #endif
 
   // NOTE: We can not track sleep duration when waking from a pin because we use
   // the crystal oscillator as the dormant clock source, so the AON timer we'd

--- a/examples/SleepRP2350Timer/SleepRP2350Timer.ino
+++ b/examples/SleepRP2350Timer/SleepRP2350Timer.ino
@@ -11,7 +11,11 @@
 // reset the AON timer correctly before running.
 
 #include <Adafruit_SleepyDog.h>
+#ifdef USE_TINYUSB
+#include <Adafruit_TinyUSB.h>
+#else
 #include "USB.h"
+#endif
 
 static bool awake;
 
@@ -58,7 +62,8 @@ void loop() {
   // Re-enable clocks, generators, USB and resume execution
   // NOTE: This MUST be called to properly resume from sleep!
   Watchdog.resumeFromSleep();
-        // Re-enable USB and Serial after sleep. Required for Windows where USB
+        #ifndef USE_TINYUSB
+  // Re-enable USB and Serial after sleep. Required for Windows where USB
     // does not re-enumerate automatically. On macOS and Linux, USB is
     // maintained across sleep cycles. If you use an external serial terminal
     // (e.g. screen, minicom), comment out USB.disconnect() and USB.connect()
@@ -67,6 +72,7 @@ void loop() {
     USB.connect();
     Serial.begin(115200);
     while (!Serial);
+  #endif
 
   Serial.println("I'm awake now!");
   Serial.print("Slept for approximately ");

--- a/examples/SleepRP2350Timer/SleepRP2350Timer.ino
+++ b/examples/SleepRP2350Timer/SleepRP2350Timer.ino
@@ -58,7 +58,7 @@ void loop() {
   // Re-enable clocks, generators, USB and resume execution
   // NOTE: This MUST be called to properly resume from sleep!
   Watchdog.resumeFromSleep();
-    // Re-enable USB and Serial for Windows/Linux compatibility
+      // Re-enable USB and Serial (required for Windows USB re-enumeration after sleep)
     USB.disconnect();
     USB.connect();
     Serial.begin(115200);

--- a/examples/SleepRP2350Timer/SleepRP2350Timer.ino
+++ b/examples/SleepRP2350Timer/SleepRP2350Timer.ino
@@ -58,7 +58,11 @@ void loop() {
   // Re-enable clocks, generators, USB and resume execution
   // NOTE: This MUST be called to properly resume from sleep!
   Watchdog.resumeFromSleep();
-      // Re-enable USB and Serial (required for Windows USB re-enumeration after sleep)
+        // Re-enable USB and Serial after sleep. Required for Windows where USB
+    // does not re-enumerate automatically. On macOS and Linux, USB is
+    // maintained across sleep cycles. If you use an external serial terminal
+    // (e.g. screen, minicom), comment out USB.disconnect() and USB.connect()
+    // to prevent the port from disconnecting on each wake cycle.
     USB.disconnect();
     USB.connect();
     Serial.begin(115200);

--- a/examples/SleepRP2350Timer/SleepRP2350Timer.ino
+++ b/examples/SleepRP2350Timer/SleepRP2350Timer.ino
@@ -69,6 +69,7 @@ void loop() {
     // (e.g. screen, minicom), comment out USB.disconnect() and USB.connect()
     // to prevent the port from disconnecting on each wake cycle.
     USB.disconnect();
+      delay(500); // Give host time to register disconnect before reconnecting
     USB.connect();
   #endif
 

--- a/examples/SleepRP2350Timer/SleepRP2350Timer.ino
+++ b/examples/SleepRP2350Timer/SleepRP2350Timer.ino
@@ -7,6 +7,8 @@
 //
 // Brent Rubell for Adafruit Industries
 //
+// NOTE: After uploading, physically unplug and replug the USB cable to
+// reset the AON timer correctly before running.
 
 #include <Adafruit_SleepyDog.h>
 

--- a/examples/SleepRP2350Timer/SleepRP2350Timer.ino
+++ b/examples/SleepRP2350Timer/SleepRP2350Timer.ino
@@ -63,15 +63,13 @@ void loop() {
   // NOTE: This MUST be called to properly resume from sleep!
   Watchdog.resumeFromSleep();
         #ifndef USE_TINYUSB
-  // Re-enable USB and Serial after sleep. Required for Windows where USB
+      // Re-enable USB after sleep. Required for Windows where USB
     // does not re-enumerate automatically. On macOS and Linux, USB is
     // maintained across sleep cycles. If you use an external serial terminal
     // (e.g. screen, minicom), comment out USB.disconnect() and USB.connect()
     // to prevent the port from disconnecting on each wake cycle.
     USB.disconnect();
     USB.connect();
-    Serial.begin(115200);
-    while (!Serial);
   #endif
 
   Serial.println("I'm awake now!");

--- a/examples/SleepRP2350Timer/SleepRP2350Timer.ino
+++ b/examples/SleepRP2350Timer/SleepRP2350Timer.ino
@@ -11,6 +11,7 @@
 // reset the AON timer correctly before running.
 
 #include <Adafruit_SleepyDog.h>
+#include "USB.h"
 
 static bool awake;
 
@@ -57,6 +58,11 @@ void loop() {
   // Re-enable clocks, generators, USB and resume execution
   // NOTE: This MUST be called to properly resume from sleep!
   Watchdog.resumeFromSleep();
+    // Re-enable USB and Serial for Windows/Linux compatibility
+    USB.disconnect();
+    USB.connect();
+    Serial.begin(115200);
+    while (!Serial);
 
   Serial.println("I'm awake now!");
   Serial.print("Slept for approximately ");


### PR DESCRIPTION
This PR tests the fix for the getcwd error using a proper upstream fix rather than the shell `rm -f` workaround.

## What changed

- Pulls ci-arduino from `tyeth-ai-assisted/ci-arduino@feature/skip-uninstall` (see adafruit/ci-arduino#223) which adds a `--skip-uninstall` flag to `build_platform.py`
- Subsequent `build_platform.py` calls pass `--skip-uninstall` so `arduino-cli lib uninstall` is skipped — preventing the getcwd error
- Also includes PR #65 (Windows USB re-enumeration fix for SleepRP2350Timer)

## Context

When `build_platform.py` is called multiple times in one CI job, `arduino-cli lib uninstall` follows the symlink `~/Arduino/libraries/Adafruit_SleepyDog → GITHUB_WORKSPACE` and deletes the checkout, causing `getcwd() failed` errors.

Depends on adafruit/ci-arduino#223.