### PR TITLE
Fix rp2 tinyusb compilation

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -24,22 +24,6 @@ jobs:
       run: |
         git clone --quiet https://github.com/adafruit/Adafruit_TinyUSB_Arduino /home/runner/Arduino/libraries/Adafruit_TinyUSB_Arduino
 
-    - name: check arduino-cli location + version
-      run: |
-        echo "CWD:"
-        pwd
-        echo "Arduino CLI location:"
-        which arduino-cli
-        echo "Arduino CLI version (and path check):"
-        arduino-cli version
-        echo "Is on PATH?"
-        echo $PATH
-        echo "Config dump / file location:"
-        arduino-cli config dump --verbose
-
-    - name: Move arduino-cli to /usr/local/bin
-      run: sudo mv $(which arduino-cli) /usr/local/bin/arduino-cli
-
     - name: test platforms
       run: |
         echo "running from $(pwd)"

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -15,12 +15,39 @@ jobs:
       with:
          repository: adafruit/ci-arduino
          path: ci
+         ref: ci-wippersnapper
 
     - name: pre-install
       run: bash ci/actions_install.sh
 
+    - name: Install extra Arduino libraries
+      run: |
+        git clone --quiet https://github.com/adafruit/Adafruit_TinyUSB_Arduino /home/runner/Arduino/libraries/Adafruit_TinyUSB_Arduino
+
+    - name: check arduino-cli location + version
+      run: |
+        echo "CWD:"
+        pwd
+        echo "Arduino CLI location:"
+        which arduino-cli
+        echo "Arduino CLI version (and path check):"
+        arduino-cli version
+        echo "Is on PATH?"
+        echo $PATH
+        echo "Config dump / file location:"
+        arduino-cli config dump --verbose
+
+    - name: Move arduino-cli to /usr/local/bin
+      run: sudo mv $(which arduino-cli) /usr/local/bin/arduino-cli
+
     - name: test platforms
-      run: python3 ci/build_platform.py main_platforms
+      run: |
+        echo "running from $(pwd)"
+        echo "arduino-cli available at: $(which arduino-cli)"
+        python3 ci/build_platform.py rp2040_platforms
+        for platform in pico_rp2040_tinyusb pico_rp2040_tinyusb_host pico_rp2350 pico_rp2350_tinyusb pico_rp2350_tinyusb_host picow_rp2040 picow_rp2040_tinyusb main_platforms; do
+          python3 ci/build_platform.py $platform --skip-uninstall
+        done
 
     - name: clang
       run: python3 ci/run-clang-format.py -e "ci/*" -e "bin/*" -r . 

--- a/examples/BasicUsage/BasicUsage.ino
+++ b/examples/BasicUsage/BasicUsage.ino
@@ -41,7 +41,7 @@ void setup() {
   Serial.println();
 
 // can not disable NRF or RP2040 wdt once enabled
-#if !defined(NRF52_SERIES) || !defined(ARDUINO_ARCH_RP2040)
+#if !defined(NRF52_SERIES) && !defined(ARDUINO_ARCH_RP2040)
   // Disable the watchdog entirely by calling Watchdog.disable();
   Watchdog.disable();
 #endif

--- a/examples/BasicUsage/BasicUsage.ino
+++ b/examples/BasicUsage/BasicUsage.ino
@@ -4,6 +4,10 @@
 //
 // Author: Tony DiCola
 
+#ifdef USE_TINYUSB
+#include <Adafruit_TinyUSB.h>  // Include TinyUSB Serial port
+#endif
+
 #include <Adafruit_SleepyDog.h>
 
 void setup() {

--- a/examples/Sleep/Sleep.ino
+++ b/examples/Sleep/Sleep.ino
@@ -4,6 +4,10 @@
 //
 // Author: Tony DiCola
 
+#ifdef USE_TINYUSB
+#include <Adafruit_TinyUSB.h>  // Include TinyUSB Serial port
+#endif
+
 #include <Adafruit_SleepyDog.h>
 
 void setup() {

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit SleepyDog Library
-version=1.8.2
+version=1.8.4
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino library to use the watchdog timer for system reset and low power sleep.


### PR DESCRIPTION
Basic and Sleep examples fail to compile with USB Stack set to tinyusb on some RP2 targets (like the pico).

This adds a conditional include if USE_TINYUSB, along with adding all the rp2 targets to the CI test run.

The CI job is temporarily pointed at adafruit/ci-arduino#ci-wippersnapper so it incorporates the --skip-uninstall feature.
There is a matching PR in ci-arduino to add the --skip-uninstall flag to build_platforms.py https://github.com/adafruit/ci-arduino/pull/224

Closes #50, #51 